### PR TITLE
feature/WAT 87 Implement create update routes

### DIFF
--- a/.github/workflows/pr-lint-build.yml
+++ b/.github/workflows/pr-lint-build.yml
@@ -2,6 +2,7 @@ name: 🏗️ Lint and Build
 
 on:
   workflow_dispatch:
+  push:
   pull_request:
     branches:
       - '**'

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,14 +5,16 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Enhance delete functionality in ContentTable with notification and dialog improvements">
-      <change afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/DeletionNotification.stories.tsx" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/DeletionNotification.translations.ts" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/DeletionNotification.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/config/i18n.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/i18n.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/entry.client.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/entry.client.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/entry.server.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/entry.server.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/modules/i18n.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/modules/i18n.server.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/tailwind.css" beforeDir="false" afterPath="$PROJECT_DIR$/app/tailwind.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -40,12 +42,12 @@
               <option name="branches">
                 <list>
                   <RecentBranch>
-                    <option name="branchName" value="feature/WAT-82_implement_delete_flow" />
-                    <option name="lastUsedInstant" value="1741901158" />
+                    <option name="branchName" value="feature/WAT-87_Implement_create_update_routes" />
+                    <option name="lastUsedInstant" value="1742034055" />
                   </RecentBranch>
                   <RecentBranch>
                     <option name="branchName" value="release/WAT-77_implement_generic_crud_flow" />
-                    <option name="lastUsedInstant" value="1741901098" />
+                    <option name="lastUsedInstant" value="1741909659" />
                   </RecentBranch>
                   <RecentBranch>
                     <option name="branchName" value="dev" />
@@ -127,7 +129,7 @@
     "Vitest.validateLogin.executor": "Run",
     "Vitest.validateLogin.should return success: false when emailaddress is invalid.executor": "Run",
     "Vitest.validateLogin.should return success: false when emailaddress is missing.executor": "Run",
-    "git-widget-placeholder": "feature/WAT-82__implement__delete__flow",
+    "git-widget-placeholder": "feature/WAT-87__Implement__create__update__routes",
     "javascript.nodejs.core.library.configured.version": "22.11.0",
     "javascript.nodejs.core.library.typings.version": "22.9.0",
     "last_opened_file_path": "/Users/lody/dev/projects/watershed-website/scaffold-templates/plop/form",
@@ -324,23 +326,8 @@
       <workItem from="1741601622656" duration="48801000" />
       <workItem from="1741788770297" duration="8020000" />
       <workItem from="1741873032040" duration="9407000" />
-      <workItem from="1741900035832" duration="8572000" />
-    </task>
-    <task id="LOCAL-00039" summary="Created EventSummary component">
-      <option name="closed" value="true" />
-      <created>1734009085091</created>
-      <option name="number" value="00039" />
-      <option name="presentableId" value="LOCAL-00039" />
-      <option name="project" value="LOCAL" />
-      <updated>1734009085091</updated>
-    </task>
-    <task id="LOCAL-00040" summary="Create artist profile summary component and added missing translations for a few components">
-      <option name="closed" value="true" />
-      <created>1734011975897</created>
-      <option name="number" value="00040" />
-      <option name="presentableId" value="LOCAL-00040" />
-      <option name="project" value="LOCAL" />
-      <updated>1734011975897</updated>
+      <workItem from="1741900035832" duration="9197000" />
+      <workItem from="1742033930615" duration="8281000" />
     </task>
     <task id="LOCAL-00041" summary="Created a summary component for one or more artists">
       <option name="closed" value="true" />
@@ -718,7 +705,23 @@
       <option name="project" value="LOCAL" />
       <updated>1741905742303</updated>
     </task>
-    <option name="localTasksCounter" value="88" />
+    <task id="LOCAL-00088" summary="Enhance delete functionality in ContentTable with notification and dialog improvements">
+      <option name="closed" value="true" />
+      <created>1741909278570</created>
+      <option name="number" value="00088" />
+      <option name="presentableId" value="LOCAL-00088" />
+      <option name="project" value="LOCAL" />
+      <updated>1741909278570</updated>
+    </task>
+    <task id="LOCAL-00089" summary="Enhance delete functionality in ContentTable with notification and dialog improvements">
+      <option name="closed" value="true" />
+      <created>1741909296958</created>
+      <option name="number" value="00089" />
+      <option name="presentableId" value="LOCAL-00089" />
+      <option name="project" value="LOCAL" />
+      <updated>1741909296958</updated>
+    </task>
+    <option name="localTasksCounter" value="90" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,14 +4,15 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Mutation forms are now processed and saved for 'Create'">
-      <change afterPath="$PROJECT_DIR$/app/types/Validations.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="The create flow is basically done, including validation before saving">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Input.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/shoelace.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/shoelace.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/project.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/project.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -324,15 +325,7 @@
       <workItem from="1741788770297" duration="8020000" />
       <workItem from="1741873032040" duration="9407000" />
       <workItem from="1741900035832" duration="9197000" />
-      <workItem from="1742033930615" duration="33182000" />
-    </task>
-    <task id="LOCAL-00046" summary="Refactored Puck block components in terms of name and label, updated Puck and added a class that allows us to use TinyMCE in Puck overriding the default pointer events setting">
-      <option name="closed" value="true" />
-      <created>1740494063007</created>
-      <option name="number" value="00046" />
-      <option name="presentableId" value="LOCAL-00046" />
-      <option name="project" value="LOCAL" />
-      <updated>1740494063007</updated>
+      <workItem from="1742033930615" duration="42663000" />
     </task>
     <task id="LOCAL-00047" summary="Added Button Block as Puck component">
       <option name="closed" value="true" />
@@ -718,7 +711,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742162384034</updated>
     </task>
-    <option name="localTasksCounter" value="95" />
+    <task id="LOCAL-00095" summary="The create flow is basically done, including validation before saving">
+      <option name="closed" value="true" />
+      <created>1742213161165</created>
+      <option name="number" value="00095" />
+      <option name="presentableId" value="LOCAL-00095" />
+      <option name="project" value="LOCAL" />
+      <updated>1742213161165</updated>
+    </task>
+    <option name="localTasksCounter" value="96" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -761,7 +762,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Turned on the future flag for route config." />
     <MESSAGE value="Removed deprecated SerializedFrom type." />
     <MESSAGE value="Ran the RRv7 codemod, manually made some improvements and fixes." />
     <MESSAGE value="Changed scripts" />
@@ -786,7 +786,8 @@
     <MESSAGE value="Created event form" />
     <MESSAGE value="Created project form, and made some smaller improvements to the event form" />
     <MESSAGE value="Mutation forms are now processed and saved for 'Create'" />
-    <option name="LAST_COMMIT_MESSAGE" value="Mutation forms are now processed and saved for 'Create'" />
+    <MESSAGE value="The create flow is basically done, including validation before saving" />
+    <option name="LAST_COMMIT_MESSAGE" value="The create flow is basically done, including validation before saving" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,14 +4,14 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Created event form">
-      <change afterPath="$PROJECT_DIR$/app/validations/models/project.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Mutation forms are now processed and saved for 'Create'">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventForm.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.translations.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/models/events.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/events.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/models/projects.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/projects.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -116,50 +116,50 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "RunOnceActivity.OpenDatabaseViewOnStart": "true",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "Vitest.All Tests.executor": "Run",
-    "Vitest.validateLogin.executor": "Run",
-    "Vitest.validateLogin.should return success: false when emailaddress is invalid.executor": "Run",
-    "Vitest.validateLogin.should return success: false when emailaddress is missing.executor": "Run",
-    "git-widget-placeholder": "feature/WAT-87__Implement__create__update__routes",
-    "javascript.nodejs.core.library.configured.version": "22.11.0",
-    "javascript.nodejs.core.library.typings.version": "22.9.0",
-    "last_opened_file_path": "/Users/lody/dev/projects/watershed-website/scaffold-templates/plop/form",
-    "node.js.detected.package.standard": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.standard": "",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_interpreter_path": "node",
-    "nodejs_package_manager_path": "npm",
-    "npm.Dev.executor": "Debug",
-    "npm.Develop.executor": "Run",
-    "npm.Storybook.executor": "Debug",
-    "npm.dev:app.executor": "Debug",
-    "npm.dev:remix.executor": "Debug",
-    "npm.dev:storybook.executor": "Debug",
-    "npm.docker:start.executor": "Run",
-    "prettierjs.PrettierConfiguration.Package": "/Users/lody/dev/projects/watershed-website/node_modules/prettier",
-    "settings.editor.selected.configurable": "settings.typescriptcompiler",
-    "ts.external.directory.path": "/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenDatabaseViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;Vitest.All Tests.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.should return success: false when emailaddress is invalid.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.should return success: false when emailaddress is missing.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/WAT-87__Implement__create__update__routes&quot;,
+    &quot;javascript.nodejs.core.library.configured.version&quot;: &quot;22.11.0&quot;,
+    &quot;javascript.nodejs.core.library.typings.version&quot;: &quot;22.9.0&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/lody/dev/projects/watershed-website/scaffold-templates/plop/form&quot;,
+    &quot;node.js.detected.package.standard&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.standard&quot;: &quot;&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_interpreter_path&quot;: &quot;node&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;npm.Dev.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.Develop.executor&quot;: &quot;Run&quot;,
+    &quot;npm.Storybook.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:app.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:remix.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:storybook.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.docker:start.executor&quot;: &quot;Run&quot;,
+    &quot;prettierjs.PrettierConfiguration.Package&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/prettier&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;settings.typescriptcompiler&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   },
-  "keyToStringList": {
-    "DatabaseDriversLRU": [
-      "postgresql"
+  &quot;keyToStringList&quot;: {
+    &quot;DatabaseDriversLRU&quot;: [
+      &quot;postgresql&quot;
     ],
-    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
-      "Markdown",
-      "TEXT",
-      "XML"
+    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
+      &quot;Markdown&quot;,
+      &quot;TEXT&quot;,
+      &quot;XML&quot;
     ]
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/scaffold-templates/plop/form" />
@@ -185,7 +185,7 @@
       <command value="Develop (npm)" />
     </option>
   </component>
-  <component name="RunManager" selected="Compound.Develop">
+  <component name="RunManager" selected="npm.Dev">
     <configuration name="Develop" type="CompoundRunConfigurationType">
       <toRun name="Dev" type="js.build_tools.npm" />
       <toRun name="Storybook" type="js.build_tools.npm" />
@@ -324,15 +324,7 @@
       <workItem from="1741788770297" duration="8020000" />
       <workItem from="1741873032040" duration="9407000" />
       <workItem from="1741900035832" duration="9197000" />
-      <workItem from="1742033930615" duration="20552000" />
-    </task>
-    <task id="LOCAL-00044" summary="Integrated the TinyMCE with Puck">
-      <option name="closed" value="true" />
-      <created>1740486346938</created>
-      <option name="number" value="00044" />
-      <option name="presentableId" value="LOCAL-00044" />
-      <option name="project" value="LOCAL" />
-      <updated>1740486346938</updated>
+      <workItem from="1742033930615" duration="21836000" />
     </task>
     <task id="LOCAL-00045" summary="Refactor Heading component and enhance RichEditor integration">
       <option name="closed" value="true" />
@@ -718,7 +710,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742160220243</updated>
     </task>
-    <option name="localTasksCounter" value="93" />
+    <task id="LOCAL-00093" summary="Created project form, and made some smaller improvements to the event form">
+      <option name="closed" value="true" />
+      <created>1742161146618</created>
+      <option name="number" value="00093" />
+      <option name="presentableId" value="LOCAL-00093" />
+      <option name="project" value="LOCAL" />
+      <updated>1742161146618</updated>
+    </task>
+    <option name="localTasksCounter" value="94" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -761,8 +761,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Changed the stream/abort timeouts" />
-    <MESSAGE value="Ignore workflow and helm templates in Prettier" />
     <MESSAGE value="Turned on the future flag for route config." />
     <MESSAGE value="Removed deprecated SerializedFrom type." />
     <MESSAGE value="Ran the RRv7 codemod, manually made some improvements and fixes." />
@@ -786,7 +784,9 @@
     <MESSAGE value="Added localised meta data for the content routes" />
     <MESSAGE value="A lot of small changes to the translations, and added a &quot;new&quot; button to te crud overview route." />
     <MESSAGE value="Created event form" />
-    <option name="LAST_COMMIT_MESSAGE" value="Created event form" />
+    <MESSAGE value="Created project form, and made some smaller improvements to the event form" />
+    <MESSAGE value="Mutation forms are now processed and saved for 'Create'" />
+    <option name="LAST_COMMIT_MESSAGE" value="Mutation forms are now processed and saved for 'Create'" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,15 +4,22 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="The create flow is basically done, including validation before saving">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component.">
+      <change afterPath="$PROJECT_DIR$/app/utils/content.test.ts" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/app/utils/content.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ContentTable.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ContentTable.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Input.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/LocaleSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocaleSelector.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/shoelace.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/shoelace.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/config/i18n.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/i18n.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/types/Content.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/types/Content.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/types/Validations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/types/Validations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/project.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/project.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -119,11 +126,15 @@
   </component>
   <component name="PropertiesComponent">{
   &quot;keyToString&quot;: {
+    &quot;Attach to Node.js/Chrome.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
+    &quot;JavaScript Debug.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
     &quot;RunOnceActivity.OpenDatabaseViewOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
     &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
     &quot;Vitest.All Tests.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.Retrieve the number of errors for each localised field.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.executor&quot;: &quot;Run&quot;,
     &quot;Vitest.validateLogin.executor&quot;: &quot;Run&quot;,
     &quot;Vitest.validateLogin.should return success: false when emailaddress is invalid.executor&quot;: &quot;Run&quot;,
     &quot;Vitest.validateLogin.should return success: false when emailaddress is missing.executor&quot;: &quot;Run&quot;,
@@ -174,6 +185,7 @@
       <recent name="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/verwijderen/$id" />
     </key>
     <key name="es6.move.members.recent.items">
+      <recent name="$PROJECT_DIR$/app/types/Content.ts" />
       <recent name="$PROJECT_DIR$/app/config/blocks/RichTextBlock.tsx" />
       <recent name="$PROJECT_DIR$/prisma/seed/_content.ts" />
       <recent name="$PROJECT_DIR$/prisma/seed/_users.ts" />
@@ -186,7 +198,7 @@
       <command value="Develop (npm)" />
     </option>
   </component>
-  <component name="RunManager" selected="npm.Dev">
+  <component name="RunManager" selected="Compound.Develop">
     <configuration name="Develop" type="CompoundRunConfigurationType">
       <toRun name="Dev" type="js.build_tools.npm" />
       <toRun name="Storybook" type="js.build_tools.npm" />
@@ -199,6 +211,33 @@
       <vitest-options value="--watch" />
       <envs />
       <scope-kind value="ALL" />
+      <method v="2" />
+    </configuration>
+    <configuration name="Content utilities" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
+      <node-interpreter value="project" />
+      <vitest-package value="$PROJECT_DIR$/node_modules/vitest" />
+      <working-dir value="$PROJECT_DIR$" />
+      <vitest-options value="--run" />
+      <envs />
+      <scope-kind value="SUITE" />
+      <test-file value="$PROJECT_DIR$/app/utils/content.test.ts" />
+      <test-names>
+        <test-name value="Content utilities" />
+      </test-names>
+      <method v="2" />
+    </configuration>
+    <configuration name="Content utilities.Retrieve the number of errors for each localised field" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
+      <node-interpreter value="project" />
+      <vitest-package value="$PROJECT_DIR$/node_modules/vitest" />
+      <working-dir value="$PROJECT_DIR$" />
+      <vitest-options value="--run" />
+      <envs />
+      <scope-kind value="TEST" />
+      <test-file value="$PROJECT_DIR$/app/utils/content.test.ts" />
+      <test-names>
+        <test-name value="Content utilities" />
+        <test-name value="Retrieve the number of errors for each localised field" />
+      </test-names>
       <method v="2" />
     </configuration>
     <configuration name="validateLogin" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
@@ -242,6 +281,10 @@
       </test-names>
       <method v="2" />
     </configuration>
+    <configuration name="Debug in Chrome" type="JavascriptDebugType" uri="http://localhost:5173">
+      <mapping url="http://localhost:5173" local-file="$PROJECT_DIR$" />
+      <method v="2" />
+    </configuration>
     <configuration name="Dev" type="js.build_tools.npm">
       <package-json value="$PROJECT_DIR$/package.json" />
       <command value="run" />
@@ -264,15 +307,20 @@
     </configuration>
     <list>
       <item itemvalue="Compound.Develop" />
+      <item itemvalue="JavaScript Debug.Debug in Chrome" />
       <item itemvalue="npm.Dev" />
       <item itemvalue="npm.Storybook" />
       <item itemvalue="Vitest.All Tests" />
+      <item itemvalue="Vitest.Content utilities" />
+      <item itemvalue="Vitest.Content utilities.Retrieve the number of errors for each localised field" />
       <item itemvalue="Vitest.validateLogin" />
       <item itemvalue="Vitest.validateLogin.should return success: false when emailaddress is invalid" />
       <item itemvalue="Vitest.validateLogin.should return success: false when emailaddress is missing" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="Vitest.Content utilities" />
+        <item itemvalue="Vitest.Content utilities.Retrieve the number of errors for each localised field" />
         <item itemvalue="Vitest.validateLogin.should return success: false when emailaddress is missing" />
         <item itemvalue="Vitest.validateLogin.should return success: false when emailaddress is invalid" />
         <item itemvalue="Vitest.validateLogin" />
@@ -325,15 +373,9 @@
       <workItem from="1741788770297" duration="8020000" />
       <workItem from="1741873032040" duration="9407000" />
       <workItem from="1741900035832" duration="9197000" />
-      <workItem from="1742033930615" duration="42663000" />
-    </task>
-    <task id="LOCAL-00047" summary="Added Button Block as Puck component">
-      <option name="closed" value="true" />
-      <created>1741173291495</created>
-      <option name="number" value="00047" />
-      <option name="presentableId" value="LOCAL-00047" />
-      <option name="project" value="LOCAL" />
-      <updated>1741173291495</updated>
+      <workItem from="1742033930615" duration="57349000" />
+      <workItem from="1742396477168" duration="4319000" />
+      <workItem from="1742482836686" duration="6623000" />
     </task>
     <task id="LOCAL-00048" summary="Changed page editor layout to feel more like an actual page">
       <option name="closed" value="true" />
@@ -719,7 +761,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742213161165</updated>
     </task>
-    <option name="localTasksCounter" value="96" />
+    <task id="LOCAL-00096" summary="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component.">
+      <option name="closed" value="true" />
+      <created>1742224442828</created>
+      <option name="number" value="00096" />
+      <option name="presentableId" value="LOCAL-00096" />
+      <option name="project" value="LOCAL" />
+      <updated>1742224442829</updated>
+    </task>
+    <option name="localTasksCounter" value="97" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -762,7 +812,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Removed deprecated SerializedFrom type." />
     <MESSAGE value="Ran the RRv7 codemod, manually made some improvements and fixes." />
     <MESSAGE value="Changed scripts" />
     <MESSAGE value="Last changes in order to switch to React Router v7" />
@@ -787,7 +836,8 @@
     <MESSAGE value="Created project form, and made some smaller improvements to the event form" />
     <MESSAGE value="Mutation forms are now processed and saved for 'Create'" />
     <MESSAGE value="The create flow is basically done, including validation before saving" />
-    <option name="LAST_COMMIT_MESSAGE" value="The create flow is basically done, including validation before saving" />
+    <MESSAGE value="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component." />
+    <option name="LAST_COMMIT_MESSAGE" value="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,15 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Fixed a lot of lint and typecheck errors">
-      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Input.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/project.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/project.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF">
+      <change beforePath="$PROJECT_DIR$/.github/workflows/pr-lint-build.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.github/workflows/pr-lint-build.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -371,15 +364,7 @@
       <workItem from="1741900035832" duration="9197000" />
       <workItem from="1742033930615" duration="57349000" />
       <workItem from="1742396477168" duration="4319000" />
-      <workItem from="1742482836686" duration="30930000" />
-    </task>
-    <task id="LOCAL-00052" summary="CI/CD improvements: Node version is now specified in an .nvmrc file for re-use. Added caching and a deploy job for the new clusters (only dev is enabled now).">
-      <option name="closed" value="true" />
-      <created>1741358118011</created>
-      <option name="number" value="00052" />
-      <option name="presentableId" value="LOCAL-00052" />
-      <option name="project" value="LOCAL" />
-      <updated>1741358118011</updated>
+      <workItem from="1742482836686" duration="30961000" />
     </task>
     <task id="LOCAL-00053" summary="Since the version number is playing a bigger role, we're moving to a beta version now.">
       <option name="closed" value="true" />
@@ -765,7 +750,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742819161843</updated>
     </task>
-    <option name="localTasksCounter" value="101" />
+    <task id="LOCAL-00101" summary="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF">
+      <option name="closed" value="true" />
+      <created>1742821051846</created>
+      <option name="number" value="00101" />
+      <option name="presentableId" value="LOCAL-00101" />
+      <option name="project" value="LOCAL" />
+      <updated>1742821051846</updated>
+    </task>
+    <option name="localTasksCounter" value="102" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -808,7 +801,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Removed some testing code I forgot to delete." />
     <MESSAGE value="Setup basic account page structure so that we can start with the admin work" />
     <MESSAGE value="Cleaned up the content structures, removing stuff we don't need. Also added link to projects for an admin" />
     <MESSAGE value="Refactored the account menu into a separate component and added admin/ route" />
@@ -833,7 +825,8 @@
     <MESSAGE value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
     <MESSAGE value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
     <MESSAGE value="Fixed a lot of lint and typecheck errors" />
-    <option name="LAST_COMMIT_MESSAGE" value="Fixed a lot of lint and typecheck errors" />
+    <MESSAGE value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
+    <option name="LAST_COMMIT_MESSAGE" value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,14 +4,15 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Fixed a lot of lint and typecheck errors">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ChangePasswordForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ChangePasswordForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ContentTable.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ContentTable.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/inloggen/LoginFormComponent.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/inloggen/LoginFormComponent.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/utils/content.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/utils/content.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Input.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/project.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/project.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -370,15 +371,7 @@
       <workItem from="1741900035832" duration="9197000" />
       <workItem from="1742033930615" duration="57349000" />
       <workItem from="1742396477168" duration="4319000" />
-      <workItem from="1742482836686" duration="28869000" />
-    </task>
-    <task id="LOCAL-00051" summary="Created Helm templates in order to deploy this application on the k8s clusters">
-      <option name="closed" value="true" />
-      <created>1741354068750</created>
-      <option name="number" value="00051" />
-      <option name="presentableId" value="LOCAL-00051" />
-      <option name="project" value="LOCAL" />
-      <updated>1741354068750</updated>
+      <workItem from="1742482836686" duration="30930000" />
     </task>
     <task id="LOCAL-00052" summary="CI/CD improvements: Node version is now specified in an .nvmrc file for re-use. Added caching and a deploy job for the new clusters (only dev is enabled now).">
       <option name="closed" value="true" />
@@ -764,7 +757,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742817052503</updated>
     </task>
-    <option name="localTasksCounter" value="100" />
+    <task id="LOCAL-00100" summary="Fixed a lot of lint and typecheck errors">
+      <option name="closed" value="true" />
+      <created>1742819161843</created>
+      <option name="number" value="00100" />
+      <option name="presentableId" value="LOCAL-00100" />
+      <option name="project" value="LOCAL" />
+      <updated>1742819161843</updated>
+    </task>
+    <option name="localTasksCounter" value="101" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -807,7 +808,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Refine route configuration and update dependencies" />
     <MESSAGE value="Removed some testing code I forgot to delete." />
     <MESSAGE value="Setup basic account page structure so that we can start with the admin work" />
     <MESSAGE value="Cleaned up the content structures, removing stuff we don't need. Also added link to projects for an admin" />
@@ -832,7 +832,8 @@
     <MESSAGE value="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting." />
     <MESSAGE value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
     <MESSAGE value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
-    <option name="LAST_COMMIT_MESSAGE" value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
+    <MESSAGE value="Fixed a lot of lint and typecheck errors" />
+    <option name="LAST_COMMIT_MESSAGE" value="Fixed a lot of lint and typecheck errors" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,16 +4,12 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="GH Actions now performs a build on normal push">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Enabled the UPDATE flow end to end.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.translations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.translations.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/models/events.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/events.server.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/models/projects.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/projects.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/LocalisedInput.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocalisedInput.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -118,55 +114,55 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Attach to Node.js/Chrome.Debug in Chrome.executor": "Debug",
-    "JavaScript Debug.Debug in Chrome.executor": "Debug",
-    "RunOnceActivity.OpenDatabaseViewOnStart": "true",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "Vitest.All Tests.executor": "Run",
-    "Vitest.Content utilities.Parse a localised form data object into a localised value object.executor": "Run",
-    "Vitest.Content utilities.Retrieve the number of errors for each localised field.executor": "Run",
-    "Vitest.Content utilities.executor": "Run",
-    "Vitest.validateLogin.executor": "Run",
-    "Vitest.validateLogin.should return success: false when emailaddress is invalid.executor": "Run",
-    "Vitest.validateLogin.should return success: false when emailaddress is missing.executor": "Run",
-    "git-widget-placeholder": "feature/WAT-87__Implement__create__update__routes",
-    "javascript.nodejs.core.library.configured.version": "22.11.0",
-    "javascript.nodejs.core.library.typings.version": "22.9.0",
-    "last_opened_file_path": "/Users/lody/dev/projects/watershed-website/scaffold-templates/plop/form",
-    "node.js.detected.package.standard": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.standard": "",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_interpreter_path": "node",
-    "nodejs_package_manager_path": "npm",
-    "npm.Dev.executor": "Debug",
-    "npm.Develop.executor": "Run",
-    "npm.Storybook.executor": "Debug",
-    "npm.dev:app.executor": "Debug",
-    "npm.dev:remix.executor": "Debug",
-    "npm.dev:storybook.executor": "Debug",
-    "npm.docker:start.executor": "Run",
-    "prettierjs.PrettierConfiguration.Package": "/Users/lody/dev/projects/watershed-website/node_modules/prettier",
-    "settings.editor.selected.configurable": "settings.typescriptcompiler",
-    "ts.external.directory.path": "/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Attach to Node.js/Chrome.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
+    &quot;JavaScript Debug.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
+    &quot;RunOnceActivity.OpenDatabaseViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;Vitest.All Tests.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.Parse a localised form data object into a localised value object.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.Retrieve the number of errors for each localised field.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.should return success: false when emailaddress is invalid.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.should return success: false when emailaddress is missing.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/WAT-87__Implement__create__update__routes&quot;,
+    &quot;javascript.nodejs.core.library.configured.version&quot;: &quot;22.11.0&quot;,
+    &quot;javascript.nodejs.core.library.typings.version&quot;: &quot;22.9.0&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/lody/dev/projects/watershed-website/scaffold-templates/plop/form&quot;,
+    &quot;node.js.detected.package.standard&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.standard&quot;: &quot;&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_interpreter_path&quot;: &quot;node&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;npm.Dev.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.Develop.executor&quot;: &quot;Run&quot;,
+    &quot;npm.Storybook.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:app.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:remix.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:storybook.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.docker:start.executor&quot;: &quot;Run&quot;,
+    &quot;prettierjs.PrettierConfiguration.Package&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/prettier&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;settings.typescriptcompiler&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   },
-  "keyToStringList": {
-    "DatabaseDriversLRU": [
-      "postgresql"
+  &quot;keyToStringList&quot;: {
+    &quot;DatabaseDriversLRU&quot;: [
+      &quot;postgresql&quot;
     ],
-    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
-      "Markdown",
-      "TEXT",
-      "XML"
+    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
+      &quot;Markdown&quot;,
+      &quot;TEXT&quot;,
+      &quot;XML&quot;
     ]
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/scaffold-templates/plop/form" />
@@ -194,7 +190,7 @@
       <command value="Develop (npm)" />
     </option>
   </component>
-  <component name="RunManager" selected="Vitest.Content utilities.Parse a localised form data object into a localised value object">
+  <component name="RunManager" selected="Compound.Develop">
     <configuration name="Develop" type="CompoundRunConfigurationType">
       <toRun name="Dev" type="js.build_tools.npm" />
       <toRun name="Storybook" type="js.build_tools.npm" />
@@ -372,15 +368,7 @@
       <workItem from="1741900035832" duration="9197000" />
       <workItem from="1742033930615" duration="57349000" />
       <workItem from="1742396477168" duration="4319000" />
-      <workItem from="1742482836686" duration="36367000" />
-    </task>
-    <task id="LOCAL-00054" summary="Fixed the invalid ingress template, and created a Dockerfile for the deployment of the app. Also adjusted helm ignore file">
-      <option name="closed" value="true" />
-      <created>1741384084997</created>
-      <option name="number" value="00054" />
-      <option name="presentableId" value="LOCAL-00054" />
-      <option name="project" value="LOCAL" />
-      <updated>1741384084997</updated>
+      <workItem from="1742482836686" duration="46242000" />
     </task>
     <task id="LOCAL-00055" summary="Added postgres as a temporary db container for the dev environment.">
       <option name="closed" value="true" />
@@ -766,7 +754,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742821098650</updated>
     </task>
-    <option name="localTasksCounter" value="103" />
+    <task id="LOCAL-00103" summary="Enabled the UPDATE flow end to end.">
+      <option name="closed" value="true" />
+      <created>1742892238660</created>
+      <option name="number" value="00103" />
+      <option name="presentableId" value="LOCAL-00103" />
+      <option name="project" value="LOCAL" />
+      <updated>1742892238660</updated>
+    </task>
+    <option name="localTasksCounter" value="104" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -809,7 +805,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Cleaned up the content structures, removing stuff we don't need. Also added link to projects for an admin" />
     <MESSAGE value="Refactored the account menu into a separate component and added admin/ route" />
     <MESSAGE value="Created the dynamic content route, and added a basic implementation of the content table." />
     <MESSAGE value="Made a basic implementation of a dynamic event/project overview" />
@@ -834,7 +829,8 @@
     <MESSAGE value="Fixed a lot of lint and typecheck errors" />
     <MESSAGE value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
     <MESSAGE value="GH Actions now performs a build on normal push" />
-    <option name="LAST_COMMIT_MESSAGE" value="GH Actions now performs a build on normal push" />
+    <MESSAGE value="Enabled the UPDATE flow end to end." />
+    <option name="LAST_COMMIT_MESSAGE" value="Enabled the UPDATE flow end to end." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,16 +4,14 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Add LocalisedInput component and enhance LocaleSelector with new props and event handling">
-      <change afterPath="$PROJECT_DIR$/app/types/DeepPartial.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ChangePasswordForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ChangePasswordForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ContentTable.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ContentTable.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/LocalisedInput.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocalisedInput.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/LocalisedInput.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocalisedInput.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/types/Validations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/types/Validations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/inloggen/LoginFormComponent.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/inloggen/LoginFormComponent.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/utils/content.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/utils/content.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -372,15 +370,7 @@
       <workItem from="1741900035832" duration="9197000" />
       <workItem from="1742033930615" duration="57349000" />
       <workItem from="1742396477168" duration="4319000" />
-      <workItem from="1742482836686" duration="27193000" />
-    </task>
-    <task id="LOCAL-00050" summary="Added footer to the editor for the Puck fields, and improved the button block">
-      <option name="closed" value="true" />
-      <created>1741335596534</created>
-      <option name="number" value="00050" />
-      <option name="presentableId" value="LOCAL-00050" />
-      <option name="project" value="LOCAL" />
-      <updated>1741335596534</updated>
+      <workItem from="1742482836686" duration="28869000" />
     </task>
     <task id="LOCAL-00051" summary="Created Helm templates in order to deploy this application on the k8s clusters">
       <option name="closed" value="true" />
@@ -766,7 +756,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742593893112</updated>
     </task>
-    <option name="localTasksCounter" value="99" />
+    <task id="LOCAL-00099" summary="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling">
+      <option name="closed" value="true" />
+      <created>1742817052503</created>
+      <option name="number" value="00099" />
+      <option name="presentableId" value="LOCAL-00099" />
+      <option name="project" value="LOCAL" />
+      <updated>1742817052503</updated>
+    </task>
+    <option name="localTasksCounter" value="100" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -809,7 +807,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Last changes in order to switch to React Router v7" />
     <MESSAGE value="Refine route configuration and update dependencies" />
     <MESSAGE value="Removed some testing code I forgot to delete." />
     <MESSAGE value="Setup basic account page structure so that we can start with the admin work" />
@@ -834,7 +831,8 @@
     <MESSAGE value="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component." />
     <MESSAGE value="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting." />
     <MESSAGE value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
-    <option name="LAST_COMMIT_MESSAGE" value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
+    <MESSAGE value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
+    <option name="LAST_COMMIT_MESSAGE" value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,17 +4,13 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Enhance delete functionality in ContentTable with notification and dialog improvements">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Added localised meta data for the content routes">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/config/i18n.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/i18n.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/entry.client.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/entry.client.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/entry.server.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/entry.server.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/modules/i18n.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/modules/i18n.server.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/tailwind.css" beforeDir="false" afterPath="$PROJECT_DIR$/app/tailwind.css" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -327,15 +323,7 @@
       <workItem from="1741788770297" duration="8020000" />
       <workItem from="1741873032040" duration="9407000" />
       <workItem from="1741900035832" duration="9197000" />
-      <workItem from="1742033930615" duration="8281000" />
-    </task>
-    <task id="LOCAL-00041" summary="Created a summary component for one or more artists">
-      <option name="closed" value="true" />
-      <created>1734012989769</created>
-      <option name="number" value="00041" />
-      <option name="presentableId" value="LOCAL-00041" />
-      <option name="project" value="LOCAL" />
-      <updated>1734012989769</updated>
+      <workItem from="1742033930615" duration="12239000" />
     </task>
     <task id="LOCAL-00042" summary="Created a summary component for a product">
       <option name="closed" value="true" />
@@ -721,7 +709,15 @@
       <option name="project" value="LOCAL" />
       <updated>1741909296958</updated>
     </task>
-    <option name="localTasksCounter" value="90" />
+    <task id="LOCAL-00090" summary="Added localised meta data for the content routes">
+      <option name="closed" value="true" />
+      <created>1742042473396</created>
+      <option name="number" value="00090" />
+      <option name="presentableId" value="LOCAL-00090" />
+      <option name="project" value="LOCAL" />
+      <updated>1742042473396</updated>
+    </task>
+    <option name="localTasksCounter" value="91" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -764,7 +760,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Updated Chart version after changes made for deployment" />
     <MESSAGE value="Changed the prisma dev deploy script to run migrate reset, which will reset the DB on each deploy." />
     <MESSAGE value="Swapped the deprecated json() functions for the new data() functions where applicable." />
     <MESSAGE value="Changed the stream/abort timeouts" />
@@ -789,7 +784,8 @@
     <MESSAGE value="Added the trash button to the content table" />
     <MESSAGE value="Implement delete functionality in ContentTable with confirmation dialog" />
     <MESSAGE value="Enhance delete functionality in ContentTable with notification and dialog improvements" />
-    <option name="LAST_COMMIT_MESSAGE" value="Enhance delete functionality in ContentTable with notification and dialog improvements" />
+    <MESSAGE value="Added localised meta data for the content routes" />
+    <option name="LAST_COMMIT_MESSAGE" value="Added localised meta data for the content routes" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,11 +4,12 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="A lot of small changes to the translations, and added a &quot;new&quot; button to te crud overview route.">
-      <change afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Created event form">
+      <change afterPath="$PROJECT_DIR$/app/validations/models/project.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Input.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.stories.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Input.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventForm.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.translations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
     </list>
@@ -323,15 +324,7 @@
       <workItem from="1741788770297" duration="8020000" />
       <workItem from="1741873032040" duration="9407000" />
       <workItem from="1741900035832" duration="9197000" />
-      <workItem from="1742033930615" duration="19643000" />
-    </task>
-    <task id="LOCAL-00043" summary="Added the improvements of generated components also to the generated form components, including some other stuff that's handy for forms">
-      <option name="closed" value="true" />
-      <created>1734019561066</created>
-      <option name="number" value="00043" />
-      <option name="presentableId" value="LOCAL-00043" />
-      <option name="project" value="LOCAL" />
-      <updated>1734019561066</updated>
+      <workItem from="1742033930615" duration="20552000" />
     </task>
     <task id="LOCAL-00044" summary="Integrated the TinyMCE with Puck">
       <option name="closed" value="true" />
@@ -717,7 +710,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742152396007</updated>
     </task>
-    <option name="localTasksCounter" value="92" />
+    <task id="LOCAL-00092" summary="Created event form">
+      <option name="closed" value="true" />
+      <created>1742160220243</created>
+      <option name="number" value="00092" />
+      <option name="presentableId" value="LOCAL-00092" />
+      <option name="project" value="LOCAL" />
+      <updated>1742160220243</updated>
+    </task>
+    <option name="localTasksCounter" value="93" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -760,7 +761,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Swapped the deprecated json() functions for the new data() functions where applicable." />
     <MESSAGE value="Changed the stream/abort timeouts" />
     <MESSAGE value="Ignore workflow and helm templates in Prettier" />
     <MESSAGE value="Turned on the future flag for route config." />
@@ -785,7 +785,8 @@
     <MESSAGE value="Enhance delete functionality in ContentTable with notification and dialog improvements" />
     <MESSAGE value="Added localised meta data for the content routes" />
     <MESSAGE value="A lot of small changes to the translations, and added a &quot;new&quot; button to te crud overview route." />
-    <option name="LAST_COMMIT_MESSAGE" value="A lot of small changes to the translations, and added a &quot;new&quot; button to te crud overview route." />
+    <MESSAGE value="Created event form" />
+    <option name="LAST_COMMIT_MESSAGE" value="Created event form" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,16 +4,16 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting.">
-      <change afterPath="$PROJECT_DIR$/app/types/Input.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Add LocalisedInput component and enhance LocaleSelector with new props and event handling">
+      <change afterPath="$PROJECT_DIR$/app/types/DeepPartial.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Input.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Input.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/LocaleSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocaleSelector.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/tailwind.css" beforeDir="false" afterPath="$PROJECT_DIR$/app/tailwind.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/LocalisedInput.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocalisedInput.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/LocalisedInput.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocalisedInput.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/types/Validations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/types/Validations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/utils/content.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/utils/content.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -118,54 +118,55 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Attach to Node.js/Chrome.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
-    &quot;JavaScript Debug.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
-    &quot;RunOnceActivity.OpenDatabaseViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;Vitest.All Tests.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.Content utilities.Retrieve the number of errors for each localised field.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.Content utilities.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.validateLogin.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.validateLogin.should return success: false when emailaddress is invalid.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.validateLogin.should return success: false when emailaddress is missing.executor&quot;: &quot;Run&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature/WAT-87__Implement__create__update__routes&quot;,
-    &quot;javascript.nodejs.core.library.configured.version&quot;: &quot;22.11.0&quot;,
-    &quot;javascript.nodejs.core.library.typings.version&quot;: &quot;22.9.0&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/lody/dev/projects/watershed-website/scaffold-templates/plop/form&quot;,
-    &quot;node.js.detected.package.standard&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.standard&quot;: &quot;&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_interpreter_path&quot;: &quot;node&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;npm.Dev.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.Develop.executor&quot;: &quot;Run&quot;,
-    &quot;npm.Storybook.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.dev:app.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.dev:remix.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.dev:storybook.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.docker:start.executor&quot;: &quot;Run&quot;,
-    &quot;prettierjs.PrettierConfiguration.Package&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/prettier&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;settings.typescriptcompiler&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Attach to Node.js/Chrome.Debug in Chrome.executor": "Debug",
+    "JavaScript Debug.Debug in Chrome.executor": "Debug",
+    "RunOnceActivity.OpenDatabaseViewOnStart": "true",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "Vitest.All Tests.executor": "Run",
+    "Vitest.Content utilities.Parse a localised form data object into a localised value object.executor": "Run",
+    "Vitest.Content utilities.Retrieve the number of errors for each localised field.executor": "Run",
+    "Vitest.Content utilities.executor": "Run",
+    "Vitest.validateLogin.executor": "Run",
+    "Vitest.validateLogin.should return success: false when emailaddress is invalid.executor": "Run",
+    "Vitest.validateLogin.should return success: false when emailaddress is missing.executor": "Run",
+    "git-widget-placeholder": "feature/WAT-87__Implement__create__update__routes",
+    "javascript.nodejs.core.library.configured.version": "22.11.0",
+    "javascript.nodejs.core.library.typings.version": "22.9.0",
+    "last_opened_file_path": "/Users/lody/dev/projects/watershed-website/scaffold-templates/plop/form",
+    "node.js.detected.package.standard": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.standard": "",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_interpreter_path": "node",
+    "nodejs_package_manager_path": "npm",
+    "npm.Dev.executor": "Debug",
+    "npm.Develop.executor": "Run",
+    "npm.Storybook.executor": "Debug",
+    "npm.dev:app.executor": "Debug",
+    "npm.dev:remix.executor": "Debug",
+    "npm.dev:storybook.executor": "Debug",
+    "npm.docker:start.executor": "Run",
+    "prettierjs.PrettierConfiguration.Package": "/Users/lody/dev/projects/watershed-website/node_modules/prettier",
+    "settings.editor.selected.configurable": "settings.typescriptcompiler",
+    "ts.external.directory.path": "/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;postgresql&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "postgresql"
     ],
-    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
-      &quot;Markdown&quot;,
-      &quot;TEXT&quot;,
-      &quot;XML&quot;
+    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
+      "Markdown",
+      "TEXT",
+      "XML"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/scaffold-templates/plop/form" />
@@ -193,7 +194,7 @@
       <command value="Develop (npm)" />
     </option>
   </component>
-  <component name="RunManager" selected="Compound.Develop">
+  <component name="RunManager" selected="Vitest.Content utilities.Parse a localised form data object into a localised value object">
     <configuration name="Develop" type="CompoundRunConfigurationType">
       <toRun name="Dev" type="js.build_tools.npm" />
       <toRun name="Storybook" type="js.build_tools.npm" />
@@ -221,6 +222,20 @@
       </test-names>
       <method v="2" />
     </configuration>
+    <configuration name="Content utilities.Parse a localised form data object into a localised value object" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
+      <node-interpreter value="project" />
+      <vitest-package value="$PROJECT_DIR$/node_modules/vitest" />
+      <working-dir value="$PROJECT_DIR$" />
+      <vitest-options value="--run" />
+      <envs />
+      <scope-kind value="TEST" />
+      <test-file value="$PROJECT_DIR$/app/utils/content.test.ts" />
+      <test-names>
+        <test-name value="Content utilities" />
+        <test-name value="Parse a localised form data object into a localised value object" />
+      </test-names>
+      <method v="2" />
+    </configuration>
     <configuration name="Content utilities.Retrieve the number of errors for each localised field" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
       <node-interpreter value="project" />
       <vitest-package value="$PROJECT_DIR$/node_modules/vitest" />
@@ -232,19 +247,6 @@
       <test-names>
         <test-name value="Content utilities" />
         <test-name value="Retrieve the number of errors for each localised field" />
-      </test-names>
-      <method v="2" />
-    </configuration>
-    <configuration name="validateLogin" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
-      <node-interpreter value="project" />
-      <vitest-package value="$PROJECT_DIR$/node_modules/vitest" />
-      <working-dir value="$PROJECT_DIR$" />
-      <vitest-options value="--run" />
-      <envs />
-      <scope-kind value="SUITE" />
-      <test-file value="$PROJECT_DIR$/app/validations/flows/login.test.ts" />
-      <test-names>
-        <test-name value="validateLogin" />
       </test-names>
       <method v="2" />
     </configuration>
@@ -306,19 +308,19 @@
       <item itemvalue="npm.Dev" />
       <item itemvalue="npm.Storybook" />
       <item itemvalue="Vitest.All Tests" />
+      <item itemvalue="Vitest.Content utilities.Parse a localised form data object into a localised value object" />
       <item itemvalue="Vitest.Content utilities" />
       <item itemvalue="Vitest.Content utilities.Retrieve the number of errors for each localised field" />
-      <item itemvalue="Vitest.validateLogin" />
       <item itemvalue="Vitest.validateLogin.should return success: false when emailaddress is invalid" />
       <item itemvalue="Vitest.validateLogin.should return success: false when emailaddress is missing" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="Vitest.Content utilities.Parse a localised form data object into a localised value object" />
         <item itemvalue="Vitest.Content utilities" />
         <item itemvalue="Vitest.Content utilities.Retrieve the number of errors for each localised field" />
         <item itemvalue="Vitest.validateLogin.should return success: false when emailaddress is missing" />
         <item itemvalue="Vitest.validateLogin.should return success: false when emailaddress is invalid" />
-        <item itemvalue="Vitest.validateLogin" />
       </list>
     </recent_temporary>
   </component>
@@ -370,15 +372,7 @@
       <workItem from="1741900035832" duration="9197000" />
       <workItem from="1742033930615" duration="57349000" />
       <workItem from="1742396477168" duration="4319000" />
-      <workItem from="1742482836686" duration="17125000" />
-    </task>
-    <task id="LOCAL-00049" summary="Added GridBlock to Puck">
-      <option name="closed" value="true" />
-      <created>1741178388146</created>
-      <option name="number" value="00049" />
-      <option name="presentableId" value="LOCAL-00049" />
-      <option name="project" value="LOCAL" />
-      <updated>1741178388146</updated>
+      <workItem from="1742482836686" duration="27193000" />
     </task>
     <task id="LOCAL-00050" summary="Added footer to the editor for the Puck fields, and improved the button block">
       <option name="closed" value="true" />
@@ -764,7 +758,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742582714602</updated>
     </task>
-    <option name="localTasksCounter" value="98" />
+    <task id="LOCAL-00098" summary="Add LocalisedInput component and enhance LocaleSelector with new props and event handling">
+      <option name="closed" value="true" />
+      <created>1742593893112</created>
+      <option name="number" value="00098" />
+      <option name="presentableId" value="LOCAL-00098" />
+      <option name="project" value="LOCAL" />
+      <updated>1742593893112</updated>
+    </task>
+    <option name="localTasksCounter" value="99" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -807,7 +809,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Changed scripts" />
     <MESSAGE value="Last changes in order to switch to React Router v7" />
     <MESSAGE value="Refine route configuration and update dependencies" />
     <MESSAGE value="Removed some testing code I forgot to delete." />
@@ -832,7 +833,8 @@
     <MESSAGE value="The create flow is basically done, including validation before saving" />
     <MESSAGE value="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component." />
     <MESSAGE value="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting." />
-    <option name="LAST_COMMIT_MESSAGE" value="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting." />
+    <MESSAGE value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
+    <option name="LAST_COMMIT_MESSAGE" value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,13 +4,13 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Added localised meta data for the content routes">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="A lot of small changes to the translations, and added a &quot;new&quot; button to te crud overview route.">
+      <change afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/entry.client.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/entry.client.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Input.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.stories.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Input.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/tailwind.css" beforeDir="false" afterPath="$PROJECT_DIR$/app/tailwind.css" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -323,15 +323,7 @@
       <workItem from="1741788770297" duration="8020000" />
       <workItem from="1741873032040" duration="9407000" />
       <workItem from="1741900035832" duration="9197000" />
-      <workItem from="1742033930615" duration="12239000" />
-    </task>
-    <task id="LOCAL-00042" summary="Created a summary component for a product">
-      <option name="closed" value="true" />
-      <created>1734014880835</created>
-      <option name="number" value="00042" />
-      <option name="presentableId" value="LOCAL-00042" />
-      <option name="project" value="LOCAL" />
-      <updated>1734014880835</updated>
+      <workItem from="1742033930615" duration="19643000" />
     </task>
     <task id="LOCAL-00043" summary="Added the improvements of generated components also to the generated form components, including some other stuff that's handy for forms">
       <option name="closed" value="true" />
@@ -717,7 +709,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742042473396</updated>
     </task>
-    <option name="localTasksCounter" value="91" />
+    <task id="LOCAL-00091" summary="A lot of small changes to the translations, and added a &quot;new&quot; button to te crud overview route.">
+      <option name="closed" value="true" />
+      <created>1742152396007</created>
+      <option name="number" value="00091" />
+      <option name="presentableId" value="LOCAL-00091" />
+      <option name="project" value="LOCAL" />
+      <updated>1742152396007</updated>
+    </task>
+    <option name="localTasksCounter" value="92" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -760,7 +760,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Changed the prisma dev deploy script to run migrate reset, which will reset the DB on each deploy." />
     <MESSAGE value="Swapped the deprecated json() functions for the new data() functions where applicable." />
     <MESSAGE value="Changed the stream/abort timeouts" />
     <MESSAGE value="Ignore workflow and helm templates in Prettier" />
@@ -785,7 +784,8 @@
     <MESSAGE value="Implement delete functionality in ContentTable with confirmation dialog" />
     <MESSAGE value="Enhance delete functionality in ContentTable with notification and dialog improvements" />
     <MESSAGE value="Added localised meta data for the content routes" />
-    <option name="LAST_COMMIT_MESSAGE" value="Added localised meta data for the content routes" />
+    <MESSAGE value="A lot of small changes to the translations, and added a &quot;new&quot; button to te crud overview route." />
+    <option name="LAST_COMMIT_MESSAGE" value="A lot of small changes to the translations, and added a &quot;new&quot; button to te crud overview route." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,22 +4,16 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component.">
-      <change afterPath="$PROJECT_DIR$/app/utils/content.test.ts" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/app/utils/content.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting.">
+      <change afterPath="$PROJECT_DIR$/app/types/Input.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ContentTable.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ContentTable.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Input.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Input.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/LocaleSelector.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocaleSelector.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/shoelace.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/shoelace.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/config/i18n.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/i18n.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/types/Content.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/types/Content.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/types/Validations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/types/Validations.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/project.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/project.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/tailwind.css" beforeDir="false" afterPath="$PROJECT_DIR$/app/tailwind.css" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -185,6 +179,7 @@
       <recent name="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/verwijderen/$id" />
     </key>
     <key name="es6.move.members.recent.items">
+      <recent name="$PROJECT_DIR$/app/types/Input.ts" />
       <recent name="$PROJECT_DIR$/app/types/Content.ts" />
       <recent name="$PROJECT_DIR$/app/config/blocks/RichTextBlock.tsx" />
       <recent name="$PROJECT_DIR$/prisma/seed/_content.ts" />
@@ -375,15 +370,7 @@
       <workItem from="1741900035832" duration="9197000" />
       <workItem from="1742033930615" duration="57349000" />
       <workItem from="1742396477168" duration="4319000" />
-      <workItem from="1742482836686" duration="6623000" />
-    </task>
-    <task id="LOCAL-00048" summary="Changed page editor layout to feel more like an actual page">
-      <option name="closed" value="true" />
-      <created>1741177410193</created>
-      <option name="number" value="00048" />
-      <option name="presentableId" value="LOCAL-00048" />
-      <option name="project" value="LOCAL" />
-      <updated>1741177410193</updated>
+      <workItem from="1742482836686" duration="17125000" />
     </task>
     <task id="LOCAL-00049" summary="Added GridBlock to Puck">
       <option name="closed" value="true" />
@@ -769,7 +756,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742224442829</updated>
     </task>
-    <option name="localTasksCounter" value="97" />
+    <task id="LOCAL-00097" summary="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting.">
+      <option name="closed" value="true" />
+      <created>1742582714601</created>
+      <option name="number" value="00097" />
+      <option name="presentableId" value="LOCAL-00097" />
+      <option name="project" value="LOCAL" />
+      <updated>1742582714602</updated>
+    </task>
+    <option name="localTasksCounter" value="98" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -812,7 +807,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Ran the RRv7 codemod, manually made some improvements and fixes." />
     <MESSAGE value="Changed scripts" />
     <MESSAGE value="Last changes in order to switch to React Router v7" />
     <MESSAGE value="Refine route configuration and update dependencies" />
@@ -837,7 +831,8 @@
     <MESSAGE value="Mutation forms are now processed and saved for 'Create'" />
     <MESSAGE value="The create flow is basically done, including validation before saving" />
     <MESSAGE value="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component." />
-    <option name="LAST_COMMIT_MESSAGE" value="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component." />
+    <MESSAGE value="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting." />
+    <option name="LAST_COMMIT_MESSAGE" value="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,8 +4,16 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF">
-      <change beforePath="$PROJECT_DIR$/.github/workflows/pr-lint-build.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.github/workflows/pr-lint-build.yml" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="GH Actions now performs a build on normal push">
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.translations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.translations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/models/events.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/events.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/models/projects.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/projects.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -364,15 +372,7 @@
       <workItem from="1741900035832" duration="9197000" />
       <workItem from="1742033930615" duration="57349000" />
       <workItem from="1742396477168" duration="4319000" />
-      <workItem from="1742482836686" duration="30961000" />
-    </task>
-    <task id="LOCAL-00053" summary="Since the version number is playing a bigger role, we're moving to a beta version now.">
-      <option name="closed" value="true" />
-      <created>1741358286575</created>
-      <option name="number" value="00053" />
-      <option name="presentableId" value="LOCAL-00053" />
-      <option name="project" value="LOCAL" />
-      <updated>1741358286575</updated>
+      <workItem from="1742482836686" duration="36367000" />
     </task>
     <task id="LOCAL-00054" summary="Fixed the invalid ingress template, and created a Dockerfile for the deployment of the app. Also adjusted helm ignore file">
       <option name="closed" value="true" />
@@ -758,7 +758,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742821051846</updated>
     </task>
-    <option name="localTasksCounter" value="102" />
+    <task id="LOCAL-00102" summary="GH Actions now performs a build on normal push">
+      <option name="closed" value="true" />
+      <created>1742821098650</created>
+      <option name="number" value="00102" />
+      <option name="presentableId" value="LOCAL-00102" />
+      <option name="project" value="LOCAL" />
+      <updated>1742821098650</updated>
+    </task>
+    <option name="localTasksCounter" value="103" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -801,7 +809,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Setup basic account page structure so that we can start with the admin work" />
     <MESSAGE value="Cleaned up the content structures, removing stuff we don't need. Also added link to projects for an admin" />
     <MESSAGE value="Refactored the account menu into a separate component and added admin/ route" />
     <MESSAGE value="Created the dynamic content route, and added a basic implementation of the content table." />
@@ -826,7 +833,8 @@
     <MESSAGE value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
     <MESSAGE value="Fixed a lot of lint and typecheck errors" />
     <MESSAGE value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
-    <option name="LAST_COMMIT_MESSAGE" value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
+    <MESSAGE value="GH Actions now performs a build on normal push" />
+    <option name="LAST_COMMIT_MESSAGE" value="GH Actions now performs a build on normal push" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Mutation forms are now processed and saved for 'Create'">
+      <change afterPath="$PROJECT_DIR$/app/types/Validations.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/models/events.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/events.server.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/models/projects.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/projects.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/validations/models/event.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/event.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/project.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/project.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -324,15 +324,7 @@
       <workItem from="1741788770297" duration="8020000" />
       <workItem from="1741873032040" duration="9407000" />
       <workItem from="1741900035832" duration="9197000" />
-      <workItem from="1742033930615" duration="21836000" />
-    </task>
-    <task id="LOCAL-00045" summary="Refactor Heading component and enhance RichEditor integration">
-      <option name="closed" value="true" />
-      <created>1740489236895</created>
-      <option name="number" value="00045" />
-      <option name="presentableId" value="LOCAL-00045" />
-      <option name="project" value="LOCAL" />
-      <updated>1740489236895</updated>
+      <workItem from="1742033930615" duration="33182000" />
     </task>
     <task id="LOCAL-00046" summary="Refactored Puck block components in terms of name and label, updated Puck and added a class that allows us to use TinyMCE in Puck overriding the default pointer events setting">
       <option name="closed" value="true" />
@@ -718,7 +710,15 @@
       <option name="project" value="LOCAL" />
       <updated>1742161146618</updated>
     </task>
-    <option name="localTasksCounter" value="94" />
+    <task id="LOCAL-00094" summary="Mutation forms are now processed and saved for 'Create'">
+      <option name="closed" value="true" />
+      <created>1742162384034</created>
+      <option name="number" value="00094" />
+      <option name="presentableId" value="LOCAL-00094" />
+      <option name="project" value="LOCAL" />
+      <updated>1742162384034</updated>
+    </task>
+    <option name="localTasksCounter" value="95" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">

--- a/app/components/ChangePasswordForm.tsx
+++ b/app/components/ChangePasswordForm.tsx
@@ -37,15 +37,13 @@ export default function ChangePasswordForm({
   const { t } = useTranslation('ChangePasswordFormComponent');
 
   const parseConfirmPasswordErrors = (errors?: ValidationErrors) => {
-    return errors?.confirmPassword
-      ?.map((error) => {
-        if (error.errorCode === 'custom') {
-          return t(`Errors.confirmPassword.${error.message}`);
-        }
+    return errors?.confirmPassword?.map((error) => {
+      if (error.errorCode === 'custom') {
+        return t(`Errors.confirmPassword.${error.message}`);
+      }
 
-        return t(`Errors.confirmPassword.${error.errorCode}`);
-      })
-      .join(', ');
+      return t(`Errors.confirmPassword.${error.errorCode}`);
+    });
   };
 
   return (
@@ -65,9 +63,9 @@ export default function ChangePasswordForm({
           type="email"
           name="emailaddress"
           label={t('EmailInputLabel')}
-          error={errors?.emailaddress
-            ?.map((error) => t(`Errors.emailaddress.${error.errorCode}`))
-            .join(', ')}
+          error={errors?.emailaddress?.map((error) =>
+            t(`Errors.emailaddress.${error.errorCode}`),
+          )}
         />
       }
 
@@ -76,9 +74,9 @@ export default function ChangePasswordForm({
         name="new-password"
         autocomplete="new-password"
         label={t('PasswordInputLabel')}
-        error={errors?.password
-          ?.map((error) => t(`Errors.password.${error.errorCode}`))
-          .join(', ')}
+        error={errors?.password?.map((error) =>
+          t(`Errors.password.${error.errorCode}`),
+        )}
       />
 
       <Input

--- a/app/components/ContentTable.tsx
+++ b/app/components/ContentTable.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 import { format, isDate } from 'date-fns';
 import Anchor from '~/components/Anchor';
 import { isLocalisedValue, LocalisedValue } from '~/types/Content';
+import { SupportedLanguages } from '~/config/i18n';
 
 type ItemValue = string | LocalisedValue | number | Date;
 
@@ -58,21 +59,25 @@ export default function ContentTable({ items, triggerDelete }: Props) {
     }
 
     if (isLocalisedValue(value)) {
-      return value[language];
+      return value[language as SupportedLanguages];
     }
 
     return value;
   }
 
   function getItemName(item: ContentTableItem) {
-    let name: LocalisedValue = {};
+    let name: LocalisedValue = {
+      en: '',
+      nl: '',
+      pap: '',
+    };
     Object.keys(item).forEach((key) => {
       if (isParametrizedItemValue(item[key]) && item[key].isName) {
         name = item[key].value as LocalisedValue;
       }
     });
 
-    return name[language];
+    return name[language as SupportedLanguages];
   }
 
   return (

--- a/app/components/ContentTable.tsx
+++ b/app/components/ContentTable.tsx
@@ -3,11 +3,8 @@ import { useTranslation } from 'react-i18next';
 import { ShoelaceContext } from '~/components/shoelace';
 import { Link } from 'react-router';
 import { format, isDate } from 'date-fns';
-import { SupportedLanguages, supportedLanguages } from '~/config/i18n';
 import Anchor from '~/components/Anchor';
-
-// TODO: Move to a shared location
-type LocalisedValue = Record<SupportedLanguages, string>;
+import { isLocalisedValue, LocalisedValue } from '~/types/Content';
 
 type ItemValue = string | LocalisedValue | number | Date;
 
@@ -28,20 +25,6 @@ type Props = {
   items: ContentTableItem[];
   triggerDelete: (itemID: string, itemName: string) => void;
 };
-
-function isSupportedLanguages(
-  value: unknown,
-): value is Record<SupportedLanguages, string> {
-  if (typeof value !== 'object' || value === null) return false;
-
-  // Get the keys from the value object
-  const keys = Object.keys(value);
-
-  // Check if all keys are valid supported languages
-  return keys.every((key) =>
-    supportedLanguages.includes(key as SupportedLanguages),
-  );
-}
 
 // Write a type predicate to check if a value is of a ParametrizedItemValue type.
 function isParametrizedItemValue(
@@ -74,7 +57,7 @@ export default function ContentTable({ items, triggerDelete }: Props) {
       return format(value, 'dd-MM-yyyy');
     }
 
-    if (isSupportedLanguages(value)) {
+    if (isLocalisedValue(value)) {
       return value[language];
     }
 

--- a/app/components/DateInput.stories.tsx
+++ b/app/components/DateInput.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import DateInput from './DateInput';
+
+export default {
+  title: 'Components/Date Input',
+  component: DateInput,
+} satisfies Meta<typeof DateInput>;
+
+type Story = StoryObj<typeof DateInput>;
+
+export const DefaultDateInput: Story = {
+  args: {
+    id: 'input',
+    label: 'This is a simple text input',
+  },
+};
+
+export const DateInputWithError: Story = {
+  args: {
+    id: 'input',
+    label: 'This is a simple text input',
+    error: ['This is an error message'],
+  },
+};

--- a/app/components/DateInput.tsx
+++ b/app/components/DateInput.tsx
@@ -1,0 +1,75 @@
+import { ComponentProps, useContext, useState } from 'react';
+import { SlInput as SlInputComponent } from '@shoelace-style/shoelace';
+import { ReactWebComponent } from '@lit/react';
+import { format, isDate, parseISO } from 'date-fns';
+import { ShoelaceContext } from '~/components/shoelace';
+import { SlInputEventHandlers } from '~/types/Input';
+
+type Props = Omit<
+  ComponentProps<ReactWebComponent<SlInputComponent>>,
+  | 'onSlBlur'
+  | 'onSlChange'
+  | 'onSlClear'
+  | 'onSlFocus'
+  | 'onSlInput'
+  | 'onSlInvalid'
+  | 'value'
+> &
+  SlInputEventHandlers & {
+    error?: string[];
+    value?: string | Date;
+  };
+
+export default function DateInput({
+  error,
+  id = '',
+  name = '',
+  className = '',
+  'aria-invalid': ariaInvalid = !!error,
+  value,
+  ...inputProps
+}: Props) {
+  const { SlInput, SlAlert } = useContext(ShoelaceContext);
+  const [dateValue, setDateValue] = useState<Date | undefined>(() => {
+    if (isDate(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value) {
+      return parseISO(value);
+    }
+
+    return undefined;
+  });
+
+  function handleDateChange(event: CustomEvent) {
+    setDateValue(new Date((event.target as HTMLInputElement)?.value));
+  }
+
+  function formatDateForInput(date: Date | undefined) {
+    if (!date) {
+      return '';
+    }
+
+    return format(date, "yyyy-MM-dd'T'HH:mm");
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SlInput
+        {...inputProps}
+        id={id}
+        className={`${className} ${error ? 'part-[base]:border-red-300' : ''}`}
+        aria-invalid={ariaInvalid}
+        aria-describedby={error ? `${id}-error` : undefined}
+        type="datetime-local"
+        value={formatDateForInput(dateValue)}
+        onSlChange={handleDateChange}
+      />
+      <input type="hidden" name={name} value={dateValue?.toISOString()} />
+      <SlAlert id={`${id}-error`} open={!!error} variant="danger">
+        {error?.join(', ')}
+      </SlAlert>
+    </div>
+  );
+}

--- a/app/components/EventForm.stories.tsx
+++ b/app/components/EventForm.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { faker } from '@faker-js/faker';
+import EventForm from './EventForm';
+import { reactRouterParameters } from 'storybook-addon-remix-react-router';
+
+export default {
+  title: 'Components/Event Form',
+  component: EventForm,
+} satisfies Meta<typeof EventForm>;
+
+type Story = StoryObj<typeof EventForm>;
+
+export const EmptyForm: Story = {
+  args: {},
+};
+
+export const FilledForm: Story = {
+  args: {
+    title: {
+      en: faker.lorem.words(),
+      nl: faker.lorem.words(),
+      pap: faker.lorem.words(),
+    },
+    description: {
+      en: faker.lorem.paragraph(),
+      nl: faker.lorem.paragraph(),
+      pap: faker.lorem.paragraph(),
+    },
+    address: `${faker.location.streetAddress()} ${faker.location.city()}, ${faker.location.state()} ${faker.location.zipCode()}`,
+    link: faker.internet.url(),
+    eventDate: faker.date.future(),
+  },
+};
+
+export const ErrorForm: Story = {
+  args: {
+    link: faker.internet.url(),
+  },
+
+  parameters: {
+    reactRouter: reactRouterParameters({
+      routing: {
+        path: '/',
+        action: async () => {
+          await new Promise((resolve) => setTimeout(resolve, 2000));
+          return {
+            errors: {
+              title: ['Title is required'],
+              description: ['Description is required'],
+              address: ['Address is required'],
+              link: ['Link is required'],
+              eventDate: ['Event date is required'],
+            },
+          };
+        },
+      },
+    }),
+  },
+};

--- a/app/components/EventForm.translations.ts
+++ b/app/components/EventForm.translations.ts
@@ -1,0 +1,31 @@
+export const en = {
+  EventForm: {
+    Title: 'New Event',
+    Labels: {
+      Title: 'Title',
+      Description: 'Description',
+      Address: 'Address',
+      Link: 'Link',
+      EventDate: 'Date',
+    },
+  },
+};
+
+export const nl = {
+  EventForm: {
+    Title: 'Nieuw evenement',
+    Labels: {
+      Title: 'Titel',
+      Description: 'Beschrijving',
+      Address: 'Adres',
+      Link: 'Link',
+      EventDate: 'Datum',
+    },
+  },
+};
+
+export const pap = {
+  EventForm: {
+    Title: '',
+  },
+};

--- a/app/components/EventForm.tsx
+++ b/app/components/EventForm.tsx
@@ -1,0 +1,89 @@
+import { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useFetcher } from 'react-router';
+import { ShoelaceContext } from '~/components/shoelace';
+import Heading from '~/components/Heading';
+import { Event } from '~/models/events.server';
+import Input from '~/components/Input';
+import { EventErrors } from '~/validations/models/event';
+
+type Props = Partial<Omit<Event, 'id' | 'createdAt' | 'updatedAt'>> & {
+  id?: string;
+};
+
+export default function EventForm({
+  id = '',
+  title,
+  description,
+  link = '',
+  address = '',
+  eventDate,
+}: Props) {
+  const { t, i18n } = useTranslation('EventForm');
+  const { SlButton } = useContext(ShoelaceContext);
+  const fetcher = useFetcher();
+
+  const localisedTitle = title ? title[i18n.language] : '';
+  const localisedDescription = description ? description[i18n.language] : '';
+
+  const errors = fetcher.data?.errors as EventErrors;
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <fetcher.Form className="space-y-4" method="post">
+      <Heading level={1}>{t('Title')}</Heading>
+
+      <input type="hidden" name="id" value={id} />
+      <Input
+        label={t('Labels.Title')}
+        name="title"
+        id="title"
+        type="text"
+        value={localisedTitle}
+        error={errors?.title}
+      />
+
+      <Input
+        label={t('Labels.Description')}
+        name="description"
+        id="description"
+        type="text"
+        value={localisedDescription}
+        error={errors?.description}
+      />
+
+      <Input
+        label={t('Labels.Address')}
+        name="address"
+        id="address"
+        type="text"
+        value={address}
+        error={errors?.address}
+      />
+
+      <Input
+        label={t('Labels.Link')}
+        id="link"
+        name="link"
+        type="url"
+        value={link}
+        error={errors?.link}
+      />
+
+      <Input
+        label={t('Labels.EventDate')}
+        name="eventDate"
+        id="eventDate"
+        type="datetime-local"
+        defaultValue={eventDate?.toISOString()}
+        error={errors?.eventDate}
+      />
+
+      <div className="flex justify-end">
+        <SlButton loading={isSubmitting} variant="primary" type="submit">
+          {t('Save')}
+        </SlButton>
+      </div>
+    </fetcher.Form>
+  );
+}

--- a/app/components/EventMutationForm.stories.tsx
+++ b/app/components/EventMutationForm.stories.tsx
@@ -3,15 +3,11 @@ import { faker } from '@faker-js/faker';
 import EventMutationForm from './EventMutationForm';
 import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 import { validateEvent } from '~/validations/models/event';
-import { expect, screen, waitFor, within } from '@storybook/test';
+import { expect, screen } from '@storybook/test';
 
 export default {
   title: 'Components/Event Mutation Form',
   component: EventMutationForm,
-  render(args) {
-    localStorage.removeItem('eventContent');
-    return <EventMutationForm {...args} />;
-  },
 } satisfies Meta<typeof EventMutationForm>;
 
 type Story = StoryObj<typeof EventMutationForm>;
@@ -39,16 +35,9 @@ export const EmptyForm: Story = {
 export const FilledForm: Story = {
   args: fakeEvent,
 
-  play: async ({ canvasElement }) => {
-    await waitFor(() =>
-      Promise.allSettled([
-        customElements.whenDefined('sl-button'),
-        customElements.whenDefined('sl-input'),
-      ]),
-    );
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const form = canvasElement.querySelector('form') as HTMLFormElement;
+  play: async () => {
+    await screen.findByText('Save');
+    const form = (await screen.findByRole('form')) as HTMLFormElement;
 
     const formData = new FormData(form);
 
@@ -88,37 +77,18 @@ export const ErrorForm: Story = {
       routing: {
         path: '/',
         action: async ({ request }) => {
-          const r = await validateEvent(request);
-          console.log(r);
-          return r;
+          return validateEvent(request);
         },
       },
     }),
   },
 
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    await waitFor(() =>
-      Promise.allSettled([
-        customElements.whenDefined('sl-button'),
-        customElements.whenDefined('sl-input'),
-      ]),
-    );
-
-    const submit = screen.getByText('Save');
-
-    if (!submit) {
-      throw new Error('Submit button not found');
-    }
+  play: async () => {
+    const submit = await screen.findByText('Save');
 
     submit.click();
 
-    await waitFor(() => {
-      expect(canvas.getByText('Invalid datetime')).toBeInTheDocument();
-      expect(
-        canvas.getByText('String must contain at least 1 character(s)'),
-      ).toBeInTheDocument();
-    });
+    screen.findByText('Invalid datetime');
+    screen.findByText('String must contain at least 1 character(s)');
   },
 };

--- a/app/components/EventMutationForm.stories.tsx
+++ b/app/components/EventMutationForm.stories.tsx
@@ -1,14 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { faker } from '@faker-js/faker';
-import EventForm from './EventForm';
+import EventMutationForm from 'app/components/EventMutationForm';
 import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 
 export default {
-  title: 'Components/Event Form',
-  component: EventForm,
-} satisfies Meta<typeof EventForm>;
+  title: 'Components/Event Mutation Form',
+  component: EventMutationForm,
+} satisfies Meta<typeof EventMutationForm>;
 
-type Story = StoryObj<typeof EventForm>;
+type Story = StoryObj<typeof EventMutationForm>;
 
 export const EmptyForm: Story = {
   args: {},
@@ -42,7 +42,6 @@ export const ErrorForm: Story = {
       routing: {
         path: '/',
         action: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 2000));
           return {
             errors: {
               title: ['Title is required'],

--- a/app/components/EventMutationForm.stories.tsx
+++ b/app/components/EventMutationForm.stories.tsx
@@ -2,6 +2,13 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { faker } from '@faker-js/faker';
 import EventMutationForm from 'app/components/EventMutationForm';
 import { reactRouterParameters } from 'storybook-addon-remix-react-router';
+import {
+  EventErrors,
+  EventValidator,
+  eventValidator,
+  validateEvent,
+} from '~/validations/models/event';
+import { ErrorResponse } from '~/types/Validations';
 
 export default {
   title: 'Components/Event Mutation Form',
@@ -27,7 +34,7 @@ const fakeEvent = {
   },
   address: `${faker.location.streetAddress()} ${faker.location.city()}, ${faker.location.state()} ${faker.location.zipCode()}`,
   link: faker.internet.url(),
-  eventDate: faker.date.future(),
+  eventDate: faker.date.future().toISOString(),
 };
 
 export const EmptyForm: Story = {
@@ -40,23 +47,25 @@ export const FilledForm: Story = {
 
 export const ErrorForm: Story = {
   args: {
+    title: {
+      en: faker.lorem.words(),
+      pap: faker.lorem.words(),
+    },
+    description: {
+      nl: faker.lorem.paragraph(),
+      pap: faker.lorem.paragraph(),
+    },
+    address: `${faker.location.streetAddress()} ${faker.location.city()}, ${faker.location.state()} ${faker.location.zipCode()}`,
     link: faker.internet.url(),
+    eventDate: faker.date.future(),
   },
 
   parameters: {
     reactRouter: reactRouterParameters({
       routing: {
         path: '/',
-        action: async () => {
-          return {
-            errors: {
-              title: ['Title is required'],
-              description: ['Description is required'],
-              address: ['Address is required'],
-              link: ['Link is required'],
-              eventDate: ['Event date is required'],
-            },
-          };
+        action: async ({ request }) => {
+          return validateEvent(request);
         },
       },
     }),

--- a/app/components/EventMutationForm.stories.tsx
+++ b/app/components/EventMutationForm.stories.tsx
@@ -25,7 +25,7 @@ const fakeEvent = {
   },
   address: `${faker.location.streetAddress()} ${faker.location.city()}, ${faker.location.state()} ${faker.location.zipCode()}`,
   link: faker.internet.url(),
-  eventDate: faker.date.future().toISOString(),
+  eventDate: faker.date.future(),
 };
 
 export const EmptyForm: Story = {
@@ -52,7 +52,9 @@ export const FilledForm: Story = {
     );
 
     await expect(formData.get('address')).toBe(fakeEvent.address);
-    await expect(formData.get('eventDate')).toBe(fakeEvent.eventDate);
+    await expect(formData.get('eventDate')).toBe(
+      fakeEvent.eventDate.toISOString(),
+    );
     await expect(formData.get('link')).toBe(fakeEvent.link);
   },
 };
@@ -69,7 +71,7 @@ export const ErrorForm: Story = {
     },
     address: `${faker.location.streetAddress()} ${faker.location.city()}, ${faker.location.state()} ${faker.location.zipCode()}`,
     link: faker.internet.url(),
-    eventDate: faker.date.future().toISOString(),
+    eventDate: faker.date.future(),
   },
 
   parameters: {

--- a/app/components/EventMutationForm.stories.tsx
+++ b/app/components/EventMutationForm.stories.tsx
@@ -6,30 +6,36 @@ import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 export default {
   title: 'Components/Event Mutation Form',
   component: EventMutationForm,
+  render(args) {
+    localStorage.removeItem('eventContent');
+    return <EventMutationForm {...args} />;
+  },
 } satisfies Meta<typeof EventMutationForm>;
 
 type Story = StoryObj<typeof EventMutationForm>;
+
+const fakeEvent = {
+  title: {
+    en: faker.lorem.words(),
+    nl: faker.lorem.words(),
+    pap: faker.lorem.words(),
+  },
+  description: {
+    en: faker.lorem.paragraph(),
+    nl: faker.lorem.paragraph(),
+    pap: faker.lorem.paragraph(),
+  },
+  address: `${faker.location.streetAddress()} ${faker.location.city()}, ${faker.location.state()} ${faker.location.zipCode()}`,
+  link: faker.internet.url(),
+  eventDate: faker.date.future(),
+};
 
 export const EmptyForm: Story = {
   args: {},
 };
 
 export const FilledForm: Story = {
-  args: {
-    title: {
-      en: faker.lorem.words(),
-      nl: faker.lorem.words(),
-      pap: faker.lorem.words(),
-    },
-    description: {
-      en: faker.lorem.paragraph(),
-      nl: faker.lorem.paragraph(),
-      pap: faker.lorem.paragraph(),
-    },
-    address: `${faker.location.streetAddress()} ${faker.location.city()}, ${faker.location.state()} ${faker.location.zipCode()}`,
-    link: faker.internet.url(),
-    eventDate: faker.date.future(),
-  },
+  args: fakeEvent,
 };
 
 export const ErrorForm: Story = {
@@ -54,5 +60,12 @@ export const ErrorForm: Story = {
         },
       },
     }),
+  },
+};
+
+export const LocalStoragePreFilledForm: Story = {
+  render() {
+    localStorage.setItem('eventContent', JSON.stringify(fakeEvent));
+    return <EventMutationForm />;
   },
 };

--- a/app/components/EventMutationForm.stories.tsx
+++ b/app/components/EventMutationForm.stories.tsx
@@ -1,10 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { faker } from '@faker-js/faker';
-import EventMutationForm from 'app/components/EventMutationForm';
+import EventMutationForm from './EventMutationForm';
 import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 import { validateEvent } from '~/validations/models/event';
-import { expect, screen, userEvent, waitFor, within } from '@storybook/test';
-import { SlButton } from '@shoelace-style/shoelace/dist/shoelace.js';
+import { expect, screen, waitFor, within } from '@storybook/test';
 
 export default {
   title: 'Components/Event Mutation Form',

--- a/app/components/EventMutationForm.stories.tsx
+++ b/app/components/EventMutationForm.stories.tsx
@@ -2,13 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { faker } from '@faker-js/faker';
 import EventMutationForm from 'app/components/EventMutationForm';
 import { reactRouterParameters } from 'storybook-addon-remix-react-router';
-import {
-  EventErrors,
-  EventValidator,
-  eventValidator,
-  validateEvent,
-} from '~/validations/models/event';
-import { ErrorResponse } from '~/types/Validations';
+import { validateEvent } from '~/validations/models/event';
+import { expect, screen, userEvent, waitFor, within } from '@storybook/test';
+import { SlButton } from '@shoelace-style/shoelace/dist/shoelace.js';
 
 export default {
   title: 'Components/Event Mutation Form',
@@ -43,6 +39,34 @@ export const EmptyForm: Story = {
 
 export const FilledForm: Story = {
   args: fakeEvent,
+
+  play: async ({ canvasElement }) => {
+    await waitFor(() =>
+      Promise.allSettled([
+        customElements.whenDefined('sl-button'),
+        customElements.whenDefined('sl-input'),
+      ]),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const form = canvasElement.querySelector('form') as HTMLFormElement;
+
+    const formData = new FormData(form);
+
+    await expect(formData.get('title.en')).toBe(fakeEvent.title.en);
+    await expect(formData.get('title.nl')).toBe(fakeEvent.title.nl);
+    await expect(formData.get('title.pap')).toBe(fakeEvent.title.pap);
+
+    await expect(formData.get('description.en')).toBe(fakeEvent.description.en);
+    await expect(formData.get('description.nl')).toBe(fakeEvent.description.nl);
+    await expect(formData.get('description.pap')).toBe(
+      fakeEvent.description.pap,
+    );
+
+    await expect(formData.get('address')).toBe(fakeEvent.address);
+    await expect(formData.get('eventDate')).toBe(fakeEvent.eventDate);
+    await expect(formData.get('link')).toBe(fakeEvent.link);
+  },
 };
 
 export const ErrorForm: Story = {
@@ -57,7 +81,7 @@ export const ErrorForm: Story = {
     },
     address: `${faker.location.streetAddress()} ${faker.location.city()}, ${faker.location.state()} ${faker.location.zipCode()}`,
     link: faker.internet.url(),
-    eventDate: faker.date.future(),
+    eventDate: faker.date.future().toISOString(),
   },
 
   parameters: {
@@ -65,16 +89,37 @@ export const ErrorForm: Story = {
       routing: {
         path: '/',
         action: async ({ request }) => {
-          return validateEvent(request);
+          const r = await validateEvent(request);
+          console.log(r);
+          return r;
         },
       },
     }),
   },
-};
 
-export const LocalStoragePreFilledForm: Story = {
-  render() {
-    localStorage.setItem('eventContent', JSON.stringify(fakeEvent));
-    return <EventMutationForm />;
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() =>
+      Promise.allSettled([
+        customElements.whenDefined('sl-button'),
+        customElements.whenDefined('sl-input'),
+      ]),
+    );
+
+    const submit = screen.getByText('Save');
+
+    if (!submit) {
+      throw new Error('Submit button not found');
+    }
+
+    submit.click();
+
+    await waitFor(() => {
+      expect(canvas.getByText('Invalid datetime')).toBeInTheDocument();
+      expect(
+        canvas.getByText('String must contain at least 1 character(s)'),
+      ).toBeInTheDocument();
+    });
   },
 };

--- a/app/components/EventMutationForm.translations.ts
+++ b/app/components/EventMutationForm.translations.ts
@@ -1,6 +1,6 @@
 export const en = {
-  EventForm: {
-    Title: 'New Event',
+  EventMutationForm: {
+    Title: 'New event',
     Labels: {
       Title: 'Title',
       Description: 'Description',
@@ -12,7 +12,7 @@ export const en = {
 };
 
 export const nl = {
-  EventForm: {
+  EventMutationForm: {
     Title: 'Nieuw evenement',
     Labels: {
       Title: 'Titel',
@@ -25,7 +25,7 @@ export const nl = {
 };
 
 export const pap = {
-  EventForm: {
+  EventMutationForm: {
     Title: '',
   },
 };

--- a/app/components/EventMutationForm.translations.ts
+++ b/app/components/EventMutationForm.translations.ts
@@ -1,6 +1,9 @@
 export const en = {
   EventMutationForm: {
-    Title: 'New event',
+    Title: {
+      New: 'New event',
+      Edit: 'Edit event',
+    },
     Labels: {
       Title: 'Title',
       Description: 'Description',
@@ -13,7 +16,10 @@ export const en = {
 
 export const nl = {
   EventMutationForm: {
-    Title: 'Nieuw evenement',
+    Title: {
+      New: 'Nieuw evenement',
+      Edit: 'Bewerk evenement',
+    },
     Labels: {
       Title: 'Titel',
       Description: 'Beschrijving',

--- a/app/components/EventMutationForm.tsx
+++ b/app/components/EventMutationForm.tsx
@@ -7,9 +7,18 @@ import { Event } from '~/models/events.server';
 import Input from '~/components/Input';
 import { ErrorResponse } from '~/types/Validations';
 import { EventErrors, EventValidator } from '~/validations/models/event';
+import LocaleSelector from '~/components/LocaleSelector';
 
 type Props = Partial<Omit<Event, 'id' | 'createdAt' | 'updatedAt'>> & {
   id?: string;
+};
+
+type EventContent = {
+  title: Record<string, string>;
+  description: Record<string, string>;
+  address: string;
+  link: string;
+  eventDate: string;
 };
 
 export default function EventMutationForm({
@@ -20,36 +29,103 @@ export default function EventMutationForm({
   const { SlButton } = useContext(ShoelaceContext);
   const fetcher = useFetcher<ErrorResponse<EventErrors, EventValidator>>();
 
-  const [title, setTitle] = useState(
-    initialValues.title ? initialValues.title[i18n.language] : '',
+  const [currentContentLocale, setCurrentContentLocale] = useState(
+    i18n.language,
   );
-  const [description, setDescription] = useState(
-    initialValues.description ? initialValues.description[i18n.language] : '',
-  );
-  const [address, setAddress] = useState(initialValues.address ?? '');
-  const [link, setLink] = useState(initialValues.link ?? '');
-  const [eventDate, setEventDate] = useState(
-    initialValues.eventDate ? initialValues.eventDate.toISOString() : '',
+  // const [title, setTitle] = useState(
+  //   initialValues.title ? initialValues.title[currentContentLocale] : '',
+  // );
+  // const [description, setDescription] = useState(
+  //   initialValues.description ?
+  //     initialValues.description[currentContentLocale]
+  //   : '',
+  // );
+  // const [address, setAddress] = useState(initialValues.address ?? '');
+  // const [link, setLink] = useState(initialValues.link ?? '');
+  // const [eventDate, setEventDate] = useState(
+  //   initialValues.eventDate ? initialValues.eventDate.toISOString() : '',
+  // );
+  const [content, setContent] = useState<Partial<EventContent> | undefined>(
+    () => {
+      if (initialValues && !!Object.values(initialValues).length)
+        return initialValues;
+
+      const cachedContent = localStorage.getItem('eventContent');
+      console.log(cachedContent);
+      if (cachedContent) return JSON.parse(cachedContent);
+
+      return {
+        title: {},
+        description: {},
+        address: '',
+        link: '',
+        eventDate: '',
+      };
+    },
   );
 
   useEffect(() => {
     if (fetcher.data) {
       const { title, description, address, link, eventDate } =
         fetcher.data.data;
-      setTitle(title);
-      setDescription(description);
-      setAddress(address);
-      setLink(link);
-      setEventDate(eventDate);
+      // setTitle(title);
+      // setDescription(description);
+      // setAddress(address);
+      // setLink(link);
+      // setEventDate(eventDate);
+      setContent({
+        title: { nl: title, en: title, pap: title },
+        description: { nl: description, en: description, pap: description },
+        address,
+        link,
+        eventDate,
+      });
     }
   }, [fetcher.data, i18n.language]);
 
   const errors = fetcher.data?.errors;
   const isSubmitting = fetcher.state !== 'idle';
 
+  const handleLocaleSelect = (locale: string) => {
+    setCurrentContentLocale(locale);
+  };
+
+  const handleChange = (field: keyof EventContent, value: string) => {
+    setContent((prev: any) => {
+      const updatedData = { ...prev, [field]: value };
+      localStorage.setItem('eventFormData', JSON.stringify(updatedData));
+      return updatedData;
+    });
+  };
+
+  const handleLocalizedChange = (
+    field: 'title' | 'description',
+    locale: string,
+    value: string,
+  ) => {
+    setContent((prev: any) => {
+      const updatedData = {
+        ...prev,
+        [field]: { ...prev[field], [locale]: value },
+      };
+      localStorage.setItem('eventFormData', JSON.stringify(updatedData));
+      return updatedData;
+    });
+  };
+
+  console.log({ content });
+
   return (
     <fetcher.Form className="space-y-4" method="post">
-      <Heading level={1}>{t('Title')}</Heading>
+      <div className="flex flex-row justify-between items-center">
+        <Heading level={1}>{t('Title')}</Heading>
+
+        <LocaleSelector
+          onLocaleSelect={handleLocaleSelect}
+          selectedLocale={currentContentLocale}
+          showSelectedLocale
+        />
+      </div>
 
       {id ?
         <input type="hidden" name="id" value={id} />
@@ -60,7 +136,14 @@ export default function EventMutationForm({
         name="title"
         id="title"
         type="text"
-        value={title}
+        value={content?.title?.[currentContentLocale] || ''}
+        onSlChange={(e) =>
+          handleLocalizedChange(
+            'title',
+            currentContentLocale,
+            (e.target as HTMLInputElement)?.value,
+          )
+        }
         error={errors?.title}
       />
 
@@ -69,7 +152,14 @@ export default function EventMutationForm({
         name="description"
         id="description"
         type="text"
-        value={description}
+        value={content?.description?.[currentContentLocale] || ''}
+        onSlChange={(e) =>
+          handleLocalizedChange(
+            'description',
+            currentContentLocale,
+            (e.target as HTMLInputElement)?.value,
+          )
+        }
         error={errors?.description}
       />
 
@@ -78,7 +168,10 @@ export default function EventMutationForm({
         name="address"
         id="address"
         type="text"
-        value={address}
+        value={content?.address || ''}
+        onSlChange={(e) =>
+          handleChange('address', (e.target as HTMLInputElement)?.value)
+        }
         error={errors?.address}
       />
 
@@ -87,7 +180,10 @@ export default function EventMutationForm({
         id="link"
         name="link"
         type="url"
-        value={link}
+        value={content?.link || ''}
+        onSlChange={(e) =>
+          handleChange('link', (e.target as HTMLInputElement)?.value)
+        }
         error={errors?.link}
       />
 
@@ -96,7 +192,10 @@ export default function EventMutationForm({
         name="eventDate"
         id="eventDate"
         type="datetime-local"
-        defaultValue={eventDate}
+        defaultValue={content?.eventDate || ''}
+        onSlChange={(e) =>
+          handleChange('eventDate', (e.target as HTMLInputElement)?.value)
+        }
         error={errors?.eventDate}
       />
 

--- a/app/components/EventMutationForm.tsx
+++ b/app/components/EventMutationForm.tsx
@@ -1,11 +1,12 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFetcher } from 'react-router';
 import { ShoelaceContext } from '~/components/shoelace';
 import Heading from '~/components/Heading';
 import { Event } from '~/models/events.server';
 import Input from '~/components/Input';
-import { EventErrors } from '~/validations/models/event';
+import { ErrorResponse } from '~/types/Validations';
+import { EventErrors, EventValidator } from '~/validations/models/event';
 
 type Props = Partial<Omit<Event, 'id' | 'createdAt' | 'updatedAt'>> & {
   id?: string;
@@ -13,20 +14,37 @@ type Props = Partial<Omit<Event, 'id' | 'createdAt' | 'updatedAt'>> & {
 
 export default function EventMutationForm({
   id = '',
-  title,
-  description,
-  link = '',
-  address = '',
-  eventDate,
+  ...initialValues
 }: Props) {
   const { t, i18n } = useTranslation('EventMutationForm');
   const { SlButton } = useContext(ShoelaceContext);
-  const fetcher = useFetcher();
+  const fetcher = useFetcher<ErrorResponse<EventErrors, EventValidator>>();
 
-  const localisedTitle = title ? title[i18n.language] : '';
-  const localisedDescription = description ? description[i18n.language] : '';
+  const [title, setTitle] = useState(
+    initialValues.title ? initialValues.title[i18n.language] : '',
+  );
+  const [description, setDescription] = useState(
+    initialValues.description ? initialValues.description[i18n.language] : '',
+  );
+  const [address, setAddress] = useState(initialValues.address ?? '');
+  const [link, setLink] = useState(initialValues.link ?? '');
+  const [eventDate, setEventDate] = useState(
+    initialValues.eventDate ? initialValues.eventDate.toISOString() : '',
+  );
 
-  const errors = fetcher.data?.errors as EventErrors;
+  useEffect(() => {
+    if (fetcher.data) {
+      const { title, description, address, link, eventDate } =
+        fetcher.data.data;
+      setTitle(title);
+      setDescription(description);
+      setAddress(address);
+      setLink(link);
+      setEventDate(eventDate);
+    }
+  }, [fetcher.data, i18n.language]);
+
+  const errors = fetcher.data?.errors;
   const isSubmitting = fetcher.state !== 'idle';
 
   return (
@@ -42,7 +60,7 @@ export default function EventMutationForm({
         name="title"
         id="title"
         type="text"
-        value={localisedTitle}
+        value={title}
         error={errors?.title}
       />
 
@@ -51,7 +69,7 @@ export default function EventMutationForm({
         name="description"
         id="description"
         type="text"
-        value={localisedDescription}
+        value={description}
         error={errors?.description}
       />
 
@@ -78,7 +96,7 @@ export default function EventMutationForm({
         name="eventDate"
         id="eventDate"
         type="datetime-local"
-        defaultValue={eventDate?.toISOString()}
+        defaultValue={eventDate}
         error={errors?.eventDate}
       />
 

--- a/app/components/EventMutationForm.tsx
+++ b/app/components/EventMutationForm.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useFetcher } from 'react-router';
 import { ShoelaceContext } from '~/components/shoelace';
@@ -6,12 +6,10 @@ import Heading from '~/components/Heading';
 import Input from '~/components/Input';
 import { ErrorResponse } from '~/types/Validations';
 import { EventErrors, EventValidator } from '~/validations/models/event';
-import LocaleSelector from '~/components/LocaleSelector';
-import { SupportedLanguages } from '~/config/i18n';
-import { countErrorsForLocalisedFields } from '~/utils/content';
-import { isLocalisedValue } from '~/types/Content';
+import LocalisedInput from '~/components/LocalisedInput';
+import { DeepPartial } from '~/types/DeepPartial';
 
-type Props = Partial<Omit<EventValidator, 'eventDate'>> & {
+type Props = DeepPartial<EventValidator> & {
   id?: string;
 };
 
@@ -19,168 +17,38 @@ export default function EventMutationForm({
   id = '',
   ...initialValues
 }: Props) {
-  const { t, i18n } = useTranslation('EventMutationForm');
+  const { t } = useTranslation('EventMutationForm');
   const { SlButton } = useContext(ShoelaceContext);
   const fetcher = useFetcher<ErrorResponse<EventErrors, EventValidator>>();
 
-  const [currentContentLocale, setCurrentContentLocale] =
-    useState<SupportedLanguages>(i18n.language as SupportedLanguages);
-
-  const [content, setContent] = useState<Partial<EventValidator> | undefined>(
-    () => {
-      if (initialValues && !!Object.values(initialValues).length)
-        return initialValues;
-
-      return undefined;
-    },
-  );
-  const [errors, setErrors] = useState<EventErrors | undefined>();
-  const [totalErrorsByLocale, setTotalErrorsByLocale] = useState<
-    Record<SupportedLanguages, number>
-  >({
-    nl: 0,
-    en: 0,
-    pap: 0,
-  });
-  const [totalErrors, setTotalErrors] = useState(0);
-
-  useEffect(() => {
-    const cachedContent = localStorage.getItem('eventContent');
-    if (cachedContent) {
-      setContent(JSON.parse(cachedContent));
-    }
-  }, []);
-
-  useEffect(() => {
-    if (fetcher.data) {
-      const { data } = fetcher.data;
-
-      const content = {} as EventValidator;
-
-      Object.keys(data).forEach((key) => {
-        if (key in data) {
-          const value = data[key as keyof EventValidator];
-
-          if (isLocalisedValue(value)) {
-            content[key as keyof EventValidator] = value;
-          } else {
-            content[key as keyof EventValidator] = value.toString();
-          }
-        }
-      });
-
-      for (const [key, value] of Object.entries<EventValidator>(data)) {
-        if (isLocalisedValue(value)) {
-          content[key] = value;
-        } else {
-          content[key as keyof EventValidator] = value.toString();
-        }
-      }
-
-      setContent(content);
-    }
-
-    if (fetcher.data?.errors) {
-      setErrors(fetcher.data.errors);
-      const totalErrors = countErrorsForLocalisedFields(fetcher.data.errors);
-      setTotalErrorsByLocale(totalErrors);
-      setTotalErrors(
-        Object.values(totalErrors).reduce((acc, curr) => acc + curr, 0),
-      );
-    }
-  }, [fetcher.data, i18n.language]);
-
   const isSubmitting = fetcher.state !== 'idle';
-
-  const handleLocaleSelect = (locale: string) => {
-    setCurrentContentLocale(locale as SupportedLanguages);
-  };
-
-  const handleChange = (field: keyof EventValidator, value: string) => {
-    setContent((prev) => {
-      const updatedData = { ...prev, [field]: value };
-      localStorage.setItem('eventContent', JSON.stringify(updatedData));
-      return updatedData;
-    });
-  };
-
-  const handleLocalizedChange = (
-    field: 'title' | 'description',
-    locale: string,
-    value: string,
-  ) => {
-    setContent((prev) => {
-      const updatedData = {
-        ...prev,
-        [field]: { ...prev[field], [locale]: value },
-      };
-      localStorage.setItem('eventContent', JSON.stringify(updatedData));
-      return updatedData;
-    });
-  };
+  const errors = fetcher.data?.errors;
+  const content = fetcher.data?.data || initialValues;
 
   return (
     <fetcher.Form className="space-y-4" method="post">
       <div className="flex flex-row justify-between items-center">
         <Heading level={1}>{t('Title')}</Heading>
-
-        <LocaleSelector
-          onLocaleSelect={handleLocaleSelect}
-          selectedLocale={currentContentLocale}
-          showSelectedLocale
-          captionBadge={totalErrors ? totalErrors.toString() : undefined}
-          localeBadges={totalErrorsByLocale}
-        />
       </div>
 
       {id ?
         <input type="hidden" name="id" value={id} />
       : null}
 
-      <Input
+      <LocalisedInput
         label={t('Labels.Title')}
-        type="text"
-        value={content?.title?.[currentContentLocale] || ''}
-        onSlChange={(e) =>
-          handleLocalizedChange(
-            'title',
-            currentContentLocale,
-            (e.target as HTMLInputElement)?.value,
-          )
-        }
-        error={errors?.title?.[currentContentLocale]?._errors}
+        name="title"
+        id="title"
+        value={content?.title}
+        errors={errors?.title}
       />
-      <input type="hidden" name="title.nl" value={content?.title?.nl || ''} />
-      <input type="hidden" name="title.en" value={content?.title?.en || ''} />
-      <input type="hidden" name="title.pap" value={content?.title?.pap || ''} />
 
-      <Input
+      <LocalisedInput
         label={t('Labels.Description')}
-        type="text"
-        value={content?.description?.[currentContentLocale] || ''}
-        onSlChange={(e) =>
-          handleLocalizedChange(
-            'description',
-            currentContentLocale,
-            (e.target as HTMLInputElement)?.value,
-          )
-        }
-        error={errors?.description?.[currentContentLocale]?._errors}
-      />
-      <input
-        type="hidden"
-        name="description.nl"
-        value={content?.description?.nl || ''}
-      />
-      <input
-        type="hidden"
-        name="description.en"
-        value={content?.description?.en || ''}
-      />
-      <input
-        type="hidden"
-        name="description.pap"
-        value={content?.description?.pap || ''}
+        name="description"
+        id="description"
+        value={content?.description}
+        errors={errors?.description}
       />
 
       <Input
@@ -189,9 +57,6 @@ export default function EventMutationForm({
         id="address"
         type="text"
         value={content?.address || ''}
-        onSlChange={(e) =>
-          handleChange('address', (e.target as HTMLInputElement)?.value)
-        }
         error={errors?.address?._errors}
       />
 
@@ -201,9 +66,6 @@ export default function EventMutationForm({
         name="link"
         type="url"
         value={content?.link || ''}
-        onSlChange={(e) =>
-          handleChange('link', (e.target as HTMLInputElement)?.value)
-        }
         error={errors?.link?._errors}
       />
 
@@ -212,10 +74,7 @@ export default function EventMutationForm({
         name="eventDate"
         id="eventDate"
         type="datetime-local"
-        defaultValue={content?.eventDate || ''}
-        onSlChange={(e) =>
-          handleChange('eventDate', (e.target as HTMLInputElement)?.value)
-        }
+        value={content?.eventDate || ''}
         error={errors?.eventDate?._errors}
       />
 

--- a/app/components/EventMutationForm.tsx
+++ b/app/components/EventMutationForm.tsx
@@ -8,9 +8,11 @@ import { ErrorResponse } from '~/types/Validations';
 import { EventErrors, EventValidator } from '~/validations/models/event';
 import LocalisedInput from '~/components/LocalisedInput';
 import { DeepPartial } from '~/types/DeepPartial';
+import { isDate } from 'date-fns';
 
-type Props = DeepPartial<EventValidator> & {
+type Props = DeepPartial<Omit<EventValidator, 'eventDate'>> & {
   id?: string;
+  eventDate?: Date;
 };
 
 export default function EventMutationForm({
@@ -23,12 +25,23 @@ export default function EventMutationForm({
 
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;
-  const content = fetcher.data?.data || initialValues;
+  const content = fetcher.data?.data || {
+    ...initialValues,
+    eventDate:
+      isDate(initialValues.eventDate) ?
+        initialValues.eventDate.toISOString()
+      : undefined,
+  };
+
+  let titleTranslationKey = 'Title.New';
+  if (id) {
+    titleTranslationKey = 'Title.Edit';
+  }
 
   return (
     <fetcher.Form name="event-form" className="space-y-4" method="post">
       <div className="flex flex-row justify-between items-center">
-        <Heading level={1}>{t('Title')}</Heading>
+        <Heading level={1}>{t(titleTranslationKey)}</Heading>
       </div>
 
       {id ?

--- a/app/components/EventMutationForm.tsx
+++ b/app/components/EventMutationForm.tsx
@@ -26,7 +26,7 @@ export default function EventMutationForm({
   const content = fetcher.data?.data || initialValues;
 
   return (
-    <fetcher.Form className="space-y-4" method="post">
+    <fetcher.Form name="event-form" className="space-y-4" method="post">
       <div className="flex flex-row justify-between items-center">
         <Heading level={1}>{t('Title')}</Heading>
       </div>

--- a/app/components/EventMutationForm.tsx
+++ b/app/components/EventMutationForm.tsx
@@ -1,0 +1,92 @@
+import { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useFetcher } from 'react-router';
+import { ShoelaceContext } from '~/components/shoelace';
+import Heading from '~/components/Heading';
+import { Event } from '~/models/events.server';
+import Input from '~/components/Input';
+import { EventErrors } from '~/validations/models/event';
+
+type Props = Partial<Omit<Event, 'id' | 'createdAt' | 'updatedAt'>> & {
+  id?: string;
+};
+
+export default function EventMutationForm({
+  id = '',
+  title,
+  description,
+  link = '',
+  address = '',
+  eventDate,
+}: Props) {
+  const { t, i18n } = useTranslation('EventMutationForm');
+  const { SlButton } = useContext(ShoelaceContext);
+  const fetcher = useFetcher();
+
+  const localisedTitle = title ? title[i18n.language] : '';
+  const localisedDescription = description ? description[i18n.language] : '';
+
+  const errors = fetcher.data?.errors as EventErrors;
+  const isSubmitting = fetcher.state !== 'idle';
+
+  return (
+    <fetcher.Form className="space-y-4" method="post">
+      <Heading level={1}>{t('Title')}</Heading>
+
+      {id ?
+        <input type="hidden" name="id" value={id} />
+      : null}
+
+      <Input
+        label={t('Labels.Title')}
+        name="title"
+        id="title"
+        type="text"
+        value={localisedTitle}
+        error={errors?.title}
+      />
+
+      <Input
+        label={t('Labels.Description')}
+        name="description"
+        id="description"
+        type="text"
+        value={localisedDescription}
+        error={errors?.description}
+      />
+
+      <Input
+        label={t('Labels.Address')}
+        name="address"
+        id="address"
+        type="text"
+        value={address}
+        error={errors?.address}
+      />
+
+      <Input
+        label={t('Labels.Link')}
+        id="link"
+        name="link"
+        type="url"
+        value={link}
+        error={errors?.link}
+      />
+
+      <Input
+        label={t('Labels.EventDate')}
+        name="eventDate"
+        id="eventDate"
+        type="datetime-local"
+        defaultValue={eventDate?.toISOString()}
+        error={errors?.eventDate}
+      />
+
+      <div className="flex justify-end">
+        <SlButton loading={isSubmitting} variant="primary" type="submit">
+          {t('Save')}
+        </SlButton>
+      </div>
+    </fetcher.Form>
+  );
+}

--- a/app/components/EventMutationForm.tsx
+++ b/app/components/EventMutationForm.tsx
@@ -3,22 +3,16 @@ import { useTranslation } from 'react-i18next';
 import { useFetcher } from 'react-router';
 import { ShoelaceContext } from '~/components/shoelace';
 import Heading from '~/components/Heading';
-import { Event } from '~/models/events.server';
 import Input from '~/components/Input';
 import { ErrorResponse } from '~/types/Validations';
 import { EventErrors, EventValidator } from '~/validations/models/event';
 import LocaleSelector from '~/components/LocaleSelector';
+import { SupportedLanguages } from '~/config/i18n';
+import { countErrorsForLocalisedFields } from '~/utils/content';
+import { isLocalisedValue } from '~/types/Content';
 
-type Props = Partial<Omit<Event, 'id' | 'createdAt' | 'updatedAt'>> & {
+type Props = Partial<Omit<EventValidator, 'eventDate'>> & {
   id?: string;
-};
-
-type EventContent = {
-  title: Record<string, string>;
-  description: Record<string, string>;
-  address: string;
-  link: string;
-  eventDate: string;
 };
 
 export default function EventMutationForm({
@@ -29,71 +23,83 @@ export default function EventMutationForm({
   const { SlButton } = useContext(ShoelaceContext);
   const fetcher = useFetcher<ErrorResponse<EventErrors, EventValidator>>();
 
-  const [currentContentLocale, setCurrentContentLocale] = useState(
-    i18n.language,
-  );
-  // const [title, setTitle] = useState(
-  //   initialValues.title ? initialValues.title[currentContentLocale] : '',
-  // );
-  // const [description, setDescription] = useState(
-  //   initialValues.description ?
-  //     initialValues.description[currentContentLocale]
-  //   : '',
-  // );
-  // const [address, setAddress] = useState(initialValues.address ?? '');
-  // const [link, setLink] = useState(initialValues.link ?? '');
-  // const [eventDate, setEventDate] = useState(
-  //   initialValues.eventDate ? initialValues.eventDate.toISOString() : '',
-  // );
-  const [content, setContent] = useState<Partial<EventContent> | undefined>(
+  const [currentContentLocale, setCurrentContentLocale] =
+    useState<SupportedLanguages>(i18n.language as SupportedLanguages);
+
+  const [content, setContent] = useState<Partial<EventValidator> | undefined>(
     () => {
       if (initialValues && !!Object.values(initialValues).length)
         return initialValues;
 
-      const cachedContent = localStorage.getItem('eventContent');
-      console.log(cachedContent);
-      if (cachedContent) return JSON.parse(cachedContent);
-
-      return {
-        title: {},
-        description: {},
-        address: '',
-        link: '',
-        eventDate: '',
-      };
+      return undefined;
     },
   );
+  const [errors, setErrors] = useState<EventErrors | undefined>();
+  const [totalErrorsByLocale, setTotalErrorsByLocale] = useState<
+    Record<SupportedLanguages, number>
+  >({
+    nl: 0,
+    en: 0,
+    pap: 0,
+  });
+  const [totalErrors, setTotalErrors] = useState(0);
+
+  useEffect(() => {
+    const cachedContent = localStorage.getItem('eventContent');
+    if (cachedContent) {
+      setContent(JSON.parse(cachedContent));
+    }
+  }, []);
 
   useEffect(() => {
     if (fetcher.data) {
-      const { title, description, address, link, eventDate } =
-        fetcher.data.data;
-      // setTitle(title);
-      // setDescription(description);
-      // setAddress(address);
-      // setLink(link);
-      // setEventDate(eventDate);
-      setContent({
-        title: { nl: title, en: title, pap: title },
-        description: { nl: description, en: description, pap: description },
-        address,
-        link,
-        eventDate,
+      const { data } = fetcher.data;
+
+      const content = {} as EventValidator;
+
+      Object.keys(data).forEach((key) => {
+        if (key in data) {
+          const value = data[key as keyof EventValidator];
+
+          if (isLocalisedValue(value)) {
+            content[key as keyof EventValidator] = value;
+          } else {
+            content[key as keyof EventValidator] = value.toString();
+          }
+        }
       });
+
+      for (const [key, value] of Object.entries<EventValidator>(data)) {
+        if (isLocalisedValue(value)) {
+          content[key] = value;
+        } else {
+          content[key as keyof EventValidator] = value.toString();
+        }
+      }
+
+      setContent(content);
+    }
+
+    if (fetcher.data?.errors) {
+      setErrors(fetcher.data.errors);
+      const totalErrors = countErrorsForLocalisedFields(fetcher.data.errors);
+      setTotalErrorsByLocale(totalErrors);
+      setTotalErrors(
+        Object.values(totalErrors).reduce((acc, curr) => acc + curr, 0),
+      );
     }
   }, [fetcher.data, i18n.language]);
 
-  const errors = fetcher.data?.errors;
   const isSubmitting = fetcher.state !== 'idle';
 
   const handleLocaleSelect = (locale: string) => {
-    setCurrentContentLocale(locale);
+    setCurrentContentLocale(locale as SupportedLanguages);
   };
 
-  const handleChange = (field: keyof EventContent, value: string) => {
-    setContent((prev: any) => {
+  const handleChange = (field: keyof EventValidator, value: string) => {
+    setContent((prev) => {
       const updatedData = { ...prev, [field]: value };
-      localStorage.setItem('eventFormData', JSON.stringify(updatedData));
+      localStorage.setItem('eventContent', JSON.stringify(updatedData));
       return updatedData;
     });
   };
@@ -103,17 +109,15 @@ export default function EventMutationForm({
     locale: string,
     value: string,
   ) => {
-    setContent((prev: any) => {
+    setContent((prev) => {
       const updatedData = {
         ...prev,
         [field]: { ...prev[field], [locale]: value },
       };
-      localStorage.setItem('eventFormData', JSON.stringify(updatedData));
+      localStorage.setItem('eventContent', JSON.stringify(updatedData));
       return updatedData;
     });
   };
-
-  console.log({ content });
 
   return (
     <fetcher.Form className="space-y-4" method="post">
@@ -124,6 +128,8 @@ export default function EventMutationForm({
           onLocaleSelect={handleLocaleSelect}
           selectedLocale={currentContentLocale}
           showSelectedLocale
+          captionBadge={totalErrors ? totalErrors.toString() : undefined}
+          localeBadges={totalErrorsByLocale}
         />
       </div>
 
@@ -133,8 +139,6 @@ export default function EventMutationForm({
 
       <Input
         label={t('Labels.Title')}
-        name="title"
-        id="title"
         type="text"
         value={content?.title?.[currentContentLocale] || ''}
         onSlChange={(e) =>
@@ -144,13 +148,14 @@ export default function EventMutationForm({
             (e.target as HTMLInputElement)?.value,
           )
         }
-        error={errors?.title}
+        error={errors?.title?.[currentContentLocale]?._errors}
       />
+      <input type="hidden" name="title.nl" value={content?.title?.nl || ''} />
+      <input type="hidden" name="title.en" value={content?.title?.en || ''} />
+      <input type="hidden" name="title.pap" value={content?.title?.pap || ''} />
 
       <Input
         label={t('Labels.Description')}
-        name="description"
-        id="description"
         type="text"
         value={content?.description?.[currentContentLocale] || ''}
         onSlChange={(e) =>
@@ -160,7 +165,22 @@ export default function EventMutationForm({
             (e.target as HTMLInputElement)?.value,
           )
         }
-        error={errors?.description}
+        error={errors?.description?.[currentContentLocale]?._errors}
+      />
+      <input
+        type="hidden"
+        name="description.nl"
+        value={content?.description?.nl || ''}
+      />
+      <input
+        type="hidden"
+        name="description.en"
+        value={content?.description?.en || ''}
+      />
+      <input
+        type="hidden"
+        name="description.pap"
+        value={content?.description?.pap || ''}
       />
 
       <Input
@@ -172,7 +192,7 @@ export default function EventMutationForm({
         onSlChange={(e) =>
           handleChange('address', (e.target as HTMLInputElement)?.value)
         }
-        error={errors?.address}
+        error={errors?.address?._errors}
       />
 
       <Input
@@ -184,7 +204,7 @@ export default function EventMutationForm({
         onSlChange={(e) =>
           handleChange('link', (e.target as HTMLInputElement)?.value)
         }
-        error={errors?.link}
+        error={errors?.link?._errors}
       />
 
       <Input
@@ -196,7 +216,7 @@ export default function EventMutationForm({
         onSlChange={(e) =>
           handleChange('eventDate', (e.target as HTMLInputElement)?.value)
         }
-        error={errors?.eventDate}
+        error={errors?.eventDate?._errors}
       />
 
       <div className="flex justify-end">

--- a/app/components/EventMutationForm.tsx
+++ b/app/components/EventMutationForm.tsx
@@ -8,7 +8,7 @@ import { ErrorResponse } from '~/types/Validations';
 import { EventErrors, EventValidator } from '~/validations/models/event';
 import LocalisedInput from '~/components/LocalisedInput';
 import { DeepPartial } from '~/types/DeepPartial';
-import { isDate } from 'date-fns';
+import DateInput from '~/components/DateInput';
 
 type Props = DeepPartial<Omit<EventValidator, 'eventDate'>> & {
   id?: string;
@@ -25,13 +25,7 @@ export default function EventMutationForm({
 
   const isSubmitting = fetcher.state !== 'idle';
   const errors = fetcher.data?.errors;
-  const content = fetcher.data?.data || {
-    ...initialValues,
-    eventDate:
-      isDate(initialValues.eventDate) ?
-        initialValues.eventDate.toISOString()
-      : undefined,
-  };
+  const content = fetcher.data?.data || initialValues;
 
   let titleTranslationKey = 'Title.New';
   if (id) {
@@ -82,11 +76,10 @@ export default function EventMutationForm({
         error={errors?.link?._errors}
       />
 
-      <Input
+      <DateInput
         label={t('Labels.EventDate')}
         name="eventDate"
         id="eventDate"
-        type="datetime-local"
         value={content?.eventDate || ''}
         error={errors?.eventDate?._errors}
       />

--- a/app/components/Input.stories.ts
+++ b/app/components/Input.stories.ts
@@ -19,6 +19,6 @@ export const TextInputWithError: Story = {
   args: {
     id: 'input',
     label: 'This is a simple text input',
-    error: 'This is an error message',
+    error: ['This is an error message'],
   },
 };

--- a/app/components/Input.stories.tsx
+++ b/app/components/Input.stories.tsx
@@ -8,7 +8,7 @@ export default {
     (Story) => (
       <div className="w-96">
         <Story />
-        </div>
+      </div>
     ),
   ],
 } satisfies Meta<typeof Input>;

--- a/app/components/Input.stories.tsx
+++ b/app/components/Input.stories.tsx
@@ -4,6 +4,13 @@ import Input from './Input';
 export default {
   title: 'Components/Input',
   component: Input,
+  decorators: [
+    (Story) => (
+      <div className="w-96">
+        <Story />
+        </div>
+    ),
+  ],
 } satisfies Meta<typeof Input>;
 
 type Story = StoryObj<typeof Input>;

--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -4,7 +4,7 @@ import { ReactWebComponent } from '@lit/react';
 import { ShoelaceContext } from '~/components/shoelace';
 
 type Props = ComponentProps<ReactWebComponent<SlInputComponent>> & {
-  error?: string;
+  error?: string[];
 };
 
 export default function Input({
@@ -26,7 +26,7 @@ export default function Input({
         aria-describedby={error ? `${id}-error` : undefined}
       />
       <SlAlert id={`${id}-error`} open={!!error} variant="danger">
-        {error}
+        {error?.join(', ')}
       </SlAlert>
     </div>
   );

--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -1,25 +1,8 @@
-import { useContext, ComponentProps } from 'react';
-import {
-  SlBlurEvent,
-  SlChangeEvent,
-  SlClearEvent,
-  SlFocusEvent,
-  SlInput as SlInputComponent,
-  SlInputEvent,
-  SlInvalidEvent,
-} from '@shoelace-style/shoelace';
+import { ComponentProps, useContext } from 'react';
+import { SlInput as SlInputComponent } from '@shoelace-style/shoelace';
 import { ReactWebComponent } from '@lit/react';
 import { ShoelaceContext } from '~/components/shoelace';
-
-// Define custom event handler types
-type SlInputEventHandlers = {
-  onSlBlur?: (e: SlBlurEvent) => void;
-  onSlChange?: (e: SlChangeEvent) => void;
-  onSlClear?: (e: SlClearEvent) => void;
-  onSlFocus?: (e: SlFocusEvent) => void;
-  onSlInput?: (e: SlInputEvent) => void;
-  onSlInvalid?: (e: SlInvalidEvent) => void;
-};
+import { SlInputEventHandlers } from '~/types/Input';
 
 type Props = Omit<
   ComponentProps<ReactWebComponent<SlInputComponent>>,

--- a/app/components/Input.tsx
+++ b/app/components/Input.tsx
@@ -1,11 +1,38 @@
 import { useContext, ComponentProps } from 'react';
-import { SlInput as SlInputComponent } from '@shoelace-style/shoelace';
+import {
+  SlBlurEvent,
+  SlChangeEvent,
+  SlClearEvent,
+  SlFocusEvent,
+  SlInput as SlInputComponent,
+  SlInputEvent,
+  SlInvalidEvent,
+} from '@shoelace-style/shoelace';
 import { ReactWebComponent } from '@lit/react';
 import { ShoelaceContext } from '~/components/shoelace';
 
-type Props = ComponentProps<ReactWebComponent<SlInputComponent>> & {
-  error?: string[];
+// Define custom event handler types
+type SlInputEventHandlers = {
+  onSlBlur?: (e: SlBlurEvent) => void;
+  onSlChange?: (e: SlChangeEvent) => void;
+  onSlClear?: (e: SlClearEvent) => void;
+  onSlFocus?: (e: SlFocusEvent) => void;
+  onSlInput?: (e: SlInputEvent) => void;
+  onSlInvalid?: (e: SlInvalidEvent) => void;
 };
+
+type Props = Omit<
+  ComponentProps<ReactWebComponent<SlInputComponent>>,
+  | 'onSlBlur'
+  | 'onSlChange'
+  | 'onSlClear'
+  | 'onSlFocus'
+  | 'onSlInput'
+  | 'onSlInvalid'
+> &
+  SlInputEventHandlers & {
+    error?: string[];
+  };
 
 export default function Input({
   error,

--- a/app/components/LocaleSelector.stories.tsx
+++ b/app/components/LocaleSelector.stories.tsx
@@ -37,3 +37,13 @@ export const ShowSelectedLocale: Story = {
     showSelectedLocale: true,
   },
 };
+
+export const Badges: Story = {
+  args: {
+    captionBadge: 5,
+    localeBadges: {
+      nl: '2',
+      en: '3',
+    },
+  },
+};

--- a/app/components/LocaleSelector.stories.tsx
+++ b/app/components/LocaleSelector.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LocaleSelector from './LocaleSelector';
+
+export default {
+  title: 'Components/Locale Selector',
+  component: LocaleSelector,
+  decorators: [
+    (Story) => (
+      <div className="h-56">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof LocaleSelector>;
+
+type Story = StoryObj<typeof LocaleSelector>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const EmitChangeLocale: Story = {
+  args: {
+    emitChangeLanguage: true,
+  },
+};
+
+export const HandleChangeEvent: Story = {
+  args: {
+    onLocaleSelect: () => 'onLocaleSelect',
+  },
+};
+
+export const ShowSelectedLocale: Story = {
+  args: {
+    selectedLocale: 'en',
+    showSelectedLocale: true,
+  },
+};

--- a/app/components/LocaleSelector.stories.tsx
+++ b/app/components/LocaleSelector.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import LocaleSelector from './LocaleSelector';
+import { expect, fn, userEvent, waitFor, within } from '@storybook/test';
 
 export default {
   title: 'Components/Locale Selector',
@@ -34,7 +35,48 @@ export const HandleChangeEvent: Story = {
 export const ShowSelectedLocale: Story = {
   args: {
     selectedLocale: 'en',
-    showSelectedLocale: true,
+    captionType: 'selected',
+    onLocaleSelect: fn(),
+  },
+
+  play: async ({ canvasElement, args, step }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+      expect(canvas.getByRole('menu')).toBeInTheDocument();
+    });
+
+    // const items = canvasElement.querySelectorAll('sl-menu-item');
+    const items = canvas.getAllByRole('menuitemcheckbox');
+    const dropdownTrigger = canvasElement.querySelector('sl-button');
+
+    await waitFor(() => {
+      expect(items[0]).toHaveTextContent('Dutch');
+      expect(items[1]).toHaveTextContent('English');
+      expect(items[2]).toHaveTextContent('Papiamentu');
+    });
+
+    if (dropdownTrigger) {
+      await step('Selecting "Dutch" locale', async () => {
+        await userEvent.click(dropdownTrigger);
+        await userEvent.click(items[0]);
+      });
+    }
+
+    await waitFor(() => {
+      expect(args.onLocaleSelect).toHaveBeenCalledWith('nl');
+    });
+
+    if (dropdownTrigger) {
+      await step('Selecting "Papiamentu" locale', async () => {
+        await userEvent.click(dropdownTrigger);
+        await userEvent.click(items[2]);
+      });
+    }
+
+    await waitFor(() => {
+      expect(args.onLocaleSelect).toHaveBeenCalledWith('pap');
+    });
   },
 };
 
@@ -45,5 +87,17 @@ export const Badges: Story = {
       nl: '2',
       en: '3',
     },
+  },
+};
+
+export const InlineButtons: Story = {
+  args: {
+    inline: true,
+  },
+};
+
+export const HoistButtons: Story = {
+  args: {
+    hoist: true,
   },
 };

--- a/app/components/LocaleSelector.translations.ts
+++ b/app/components/LocaleSelector.translations.ts
@@ -1,0 +1,32 @@
+export const en = {
+  LocaleSelector: {
+    ButtonCaption: 'Language',
+    Locales: {
+      en: 'English',
+      nl: 'Dutch',
+      pap: 'Papiamentu',
+    },
+  },
+};
+
+export const nl = {
+  LocaleSelector: {
+    ButtonCaption: 'Taal',
+    Locales: {
+      en: 'Engels',
+      nl: 'Nederlands',
+      pap: 'Papiaments',
+    },
+  },
+};
+
+export const pap = {
+  LocaleSelector: {
+    ButtonCaption: 'Idioma',
+    Locales: {
+      en: 'Ingles',
+      nl: 'Neerlandes',
+      pap: 'Papiamentu',
+    },
+  },
+};

--- a/app/components/LocaleSelector.tsx
+++ b/app/components/LocaleSelector.tsx
@@ -23,6 +23,16 @@ type Props = {
    * Whether to show the selected locale in the button caption.
    */
   showSelectedLocale?: boolean;
+
+  /**
+   * Badge to display in the button caption.
+   */
+  captionBadge?: string | number;
+
+  /**
+   * Badges to display in the locale list
+   */
+  localeBadges?: Record<string, string | number>;
 };
 
 export default function LocaleSelector({
@@ -30,9 +40,11 @@ export default function LocaleSelector({
   emitChangeLanguage,
   selectedLocale,
   showSelectedLocale,
+  captionBadge,
+  localeBadges,
 }: Props) {
   const { t, i18n } = useTranslation('LocaleSelector');
-  const { SlButton, SlIcon, SlDropdown, SlMenu, SlMenuItem } =
+  const { SlButton, SlIcon, SlDropdown, SlMenu, SlMenuItem, SlBadge } =
     useContext(ShoelaceContext);
 
   const handleLocaleSelect = (event: CustomEvent) => {
@@ -56,6 +68,12 @@ export default function LocaleSelector({
         {showSelectedLocale ?
           t(`Locales.${selectedLocale}`)
         : t('ButtonCaption')}
+
+        {captionBadge ?
+          <SlBadge variant="primary" pill>
+            {captionBadge}
+          </SlBadge>
+        : null}
       </SlButton>
 
       <SlMenu onSlSelect={handleLocaleSelect}>
@@ -65,6 +83,11 @@ export default function LocaleSelector({
           value="nl"
         >
           {t('Locales.nl')}
+          {localeBadges?.nl ?
+            <SlBadge slot="suffix" variant="primary" pill>
+              {localeBadges.nl}
+            </SlBadge>
+          : null}
         </SlMenuItem>
         <SlMenuItem
           type="checkbox"
@@ -72,6 +95,11 @@ export default function LocaleSelector({
           value="en"
         >
           {t('Locales.en')}
+          {localeBadges?.en ?
+            <SlBadge slot="suffix" variant="primary" pill>
+              {localeBadges.en}
+            </SlBadge>
+          : null}
         </SlMenuItem>
         <SlMenuItem
           type="checkbox"
@@ -79,6 +107,11 @@ export default function LocaleSelector({
           value="pap"
         >
           {t('Locales.pap')}
+          {localeBadges?.pap ?
+            <SlBadge slot="suffix" variant="primary" pill>
+              {localeBadges.pap}
+            </SlBadge>
+          : null}
         </SlMenuItem>
       </SlMenu>
     </SlDropdown>

--- a/app/components/LocaleSelector.tsx
+++ b/app/components/LocaleSelector.tsx
@@ -1,0 +1,86 @@
+import { useContext } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ShoelaceContext } from '~/components/shoelace';
+
+type Props = {
+  /**
+   * Callback function that is called when a locale is selected.
+   * @param locale
+   */
+  onLocaleSelect?: (locale: string) => void;
+
+  /**
+   * Whether to emit a change language event to the app (changes the app's locale).
+   */
+  emitChangeLanguage?: boolean;
+
+  /**
+   * The currently selected locale.
+   */
+  selectedLocale?: string;
+
+  /**
+   * Whether to show the selected locale in the button caption.
+   */
+  showSelectedLocale?: boolean;
+};
+
+export default function LocaleSelector({
+  onLocaleSelect,
+  emitChangeLanguage,
+  selectedLocale,
+  showSelectedLocale,
+}: Props) {
+  const { t, i18n } = useTranslation('LocaleSelector');
+  const { SlButton, SlIcon, SlDropdown, SlMenu, SlMenuItem } =
+    useContext(ShoelaceContext);
+
+  const handleLocaleSelect = (event: CustomEvent) => {
+    const locale = event.detail.item.value;
+
+    if (emitChangeLanguage) {
+      i18n.changeLanguage(locale).catch((error) => {
+        console.error(error);
+      });
+    }
+
+    if (onLocaleSelect) {
+      onLocaleSelect(locale);
+    }
+  };
+
+  return (
+    <SlDropdown>
+      <SlButton slot="trigger" type="button" caret>
+        <SlIcon name="globe-europe-africa" slot="prefix" />
+        {showSelectedLocale ?
+          t(`Locales.${selectedLocale}`)
+        : t('ButtonCaption')}
+      </SlButton>
+
+      <SlMenu onSlSelect={handleLocaleSelect}>
+        <SlMenuItem
+          type="checkbox"
+          checked={selectedLocale === 'nl'}
+          value="nl"
+        >
+          {t('Locales.nl')}
+        </SlMenuItem>
+        <SlMenuItem
+          type="checkbox"
+          checked={selectedLocale === 'en'}
+          value="en"
+        >
+          {t('Locales.en')}
+        </SlMenuItem>
+        <SlMenuItem
+          type="checkbox"
+          checked={selectedLocale === 'pap'}
+          value="pap"
+        >
+          {t('Locales.pap')}
+        </SlMenuItem>
+      </SlMenu>
+    </SlDropdown>
+  );
+}

--- a/app/components/LocaleSelector.tsx
+++ b/app/components/LocaleSelector.tsx
@@ -1,13 +1,14 @@
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ShoelaceContext } from '~/components/shoelace';
+import { SupportedLanguages } from '~/config/i18n';
 
 type Props = {
   /**
    * Callback function that is called when a locale is selected.
    * @param locale
    */
-  onLocaleSelect?: (locale: string) => void;
+  onLocaleSelect?: (locale: SupportedLanguages) => void;
 
   /**
    * Whether to emit a change language event to the app (changes the app's locale).
@@ -17,12 +18,17 @@ type Props = {
   /**
    * The currently selected locale.
    */
-  selectedLocale?: string;
+  selectedLocale?: SupportedLanguages;
 
   /**
-   * Whether to show the selected locale in the button caption.
+   * Which caption to show in the button.
    */
-  showSelectedLocale?: boolean;
+  captionType?: 'default' | 'selected' | 'custom' | 'none';
+
+  /**
+   * If `captionType` is `custom`, the custom caption to show in the button.
+   */
+  buttonCaption?: string;
 
   /**
    * Badge to display in the button caption.
@@ -33,15 +39,34 @@ type Props = {
    * Badges to display in the locale list
    */
   localeBadges?: Record<string, string | number>;
+
+  /**
+   * The slot to render the component in.
+   */
+  slot?: string;
+
+  /**
+   * Whether to render the component inline (without borders and captions).
+   */
+  inline?: boolean;
+
+  /**
+   * Whether to hoist the dropdown menu to the body.
+   */
+  hoist?: boolean;
 };
 
 export default function LocaleSelector({
   onLocaleSelect,
   emitChangeLanguage,
   selectedLocale,
-  showSelectedLocale,
+  captionType = 'default',
+  buttonCaption = '',
   captionBadge,
   localeBadges,
+  slot = '',
+  inline = false,
+  hoist = false,
 }: Props) {
   const { t, i18n } = useTranslation('LocaleSelector');
   const { SlButton, SlIcon, SlDropdown, SlMenu, SlMenuItem, SlBadge } =
@@ -61,16 +86,38 @@ export default function LocaleSelector({
     }
   };
 
+  let caption;
+  switch (captionType) {
+    case 'default':
+      caption = t('ButtonCaption');
+      break;
+    case 'selected':
+      caption = t(`Locales.${selectedLocale}`);
+      break;
+    case 'custom':
+      caption = buttonCaption;
+      break;
+    case 'none':
+      caption = '';
+      break;
+  }
+
   return (
-    <SlDropdown>
-      <SlButton slot="trigger" type="button" caret>
+    <SlDropdown slot={slot} hoist={hoist}>
+      <SlButton
+        className={
+          inline || captionType === 'none' ? 'inline-locale-selector' : ''
+        }
+        slot="trigger"
+        type="button"
+        variant={inline ? 'text' : 'default'}
+        caret
+      >
         <SlIcon name="globe-europe-africa" slot="prefix" />
-        {showSelectedLocale ?
-          t(`Locales.${selectedLocale}`)
-        : t('ButtonCaption')}
+        {caption ? caption : null}
 
         {captionBadge ?
-          <SlBadge variant="primary" pill>
+          <SlBadge variant="danger" pill>
             {captionBadge}
           </SlBadge>
         : null}
@@ -84,7 +131,7 @@ export default function LocaleSelector({
         >
           {t('Locales.nl')}
           {localeBadges?.nl ?
-            <SlBadge slot="suffix" variant="primary" pill>
+            <SlBadge slot="suffix" variant="danger" pill>
               {localeBadges.nl}
             </SlBadge>
           : null}
@@ -96,7 +143,7 @@ export default function LocaleSelector({
         >
           {t('Locales.en')}
           {localeBadges?.en ?
-            <SlBadge slot="suffix" variant="primary" pill>
+            <SlBadge slot="suffix" variant="danger" pill>
               {localeBadges.en}
             </SlBadge>
           : null}
@@ -108,7 +155,7 @@ export default function LocaleSelector({
         >
           {t('Locales.pap')}
           {localeBadges?.pap ?
-            <SlBadge slot="suffix" variant="primary" pill>
+            <SlBadge slot="suffix" variant="danger" pill>
               {localeBadges.pap}
             </SlBadge>
           : null}

--- a/app/components/LocalisedInput.stories.tsx
+++ b/app/components/LocalisedInput.stories.tsx
@@ -1,0 +1,115 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import LocalisedInput from './LocalisedInput';
+import { fn, waitFor, within, expect } from '@storybook/test';
+import { reactRouterParameters } from 'storybook-addon-remix-react-router';
+
+export default {
+  title: 'Components/Localised Input',
+  component: LocalisedInput,
+  decorators: [
+    (Story) => (
+      <div className="w-96">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      story: {
+        height: '250px',
+      },
+    },
+  },
+} satisfies Meta<typeof LocalisedInput>;
+
+type Story = StoryObj<typeof LocalisedInput>;
+
+export const Default: Story = {
+  args: {
+    id: 'input',
+    label: 'This is a simple text input',
+  },
+};
+
+export const WithFormData: Story = {
+  args: {
+    id: 'input',
+    name: 'input',
+    label: 'This is a simple text input with multiple values',
+    value: {
+      nl: 'Dit is de Nederlandse waarde',
+      en: 'This is the English value',
+      pap: 'Esaki ta e balor na Papiamentu',
+    },
+  },
+
+  parameters: {
+    reactRouter: reactRouterParameters({
+      routing: {
+        path: '/',
+        action: async ({ request }) => {
+          const formData = await request.formData();
+          const values = Object.fromEntries(formData);
+
+          console.log(values);
+
+          return values;
+        },
+      },
+    }),
+  },
+
+  render: (args) => {
+    return (
+      <form data-testid="form">
+        <LocalisedInput {...args} />
+        <button type="submit">Submit</button>
+      </form>
+    );
+  },
+
+  play: async ({ canvasElement, args, step }) => {
+    const canvas = within(canvasElement);
+
+    const form = canvas.getByTestId('form') as HTMLFormElement;
+    let formData: FormData;
+    const submitHandler = fn();
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      formData = new FormData(form);
+      submitHandler();
+    });
+
+    await step('Submit the form', async () => {
+      form.requestSubmit();
+    });
+
+    await waitFor(() => expect(submitHandler).toHaveBeenCalled());
+    await waitFor(() => expect(formData).toBeDefined());
+    await waitFor(() => expect(formData.get('input.nl')).toBe(args.value?.nl));
+    await waitFor(() => expect(formData.get('input.en')).toBe(args.value?.en));
+    await waitFor(() =>
+      expect(formData.get('input.pap')).toBe(args.value?.pap),
+    );
+  },
+};
+
+export const WithErrors: Story = {
+  args: {
+    id: 'input',
+    label: 'This is a simple text input with some errors',
+    errors: {
+      nl: ['Dit is een foutmelding'],
+      en: ['This is an error message'],
+    },
+  },
+
+  parameters: {
+    docs: {
+      story: {
+        height: '300px',
+      },
+    },
+  },
+};

--- a/app/components/LocalisedInput.stories.tsx
+++ b/app/components/LocalisedInput.stories.tsx
@@ -100,8 +100,8 @@ export const WithErrors: Story = {
     id: 'input',
     label: 'This is a simple text input with some errors',
     errors: {
-      nl: ['Dit is een foutmelding'],
-      en: ['This is an error message'],
+      nl: { _errors: ['Dit is een foutmelding'] },
+      pap: { _errors: ['Esaki ta un mensahe di error'] },
     },
   },
 

--- a/app/components/LocalisedInput.translations.ts
+++ b/app/components/LocalisedInput.translations.ts
@@ -1,0 +1,29 @@
+export const en = {
+  LocalisedInput: {
+    Locales: {
+      en: 'English',
+      nl: 'Dutch',
+      pap: 'Papiamentu',
+    },
+  },
+};
+
+export const nl = {
+  LocalisedInput: {
+    Locales: {
+      en: 'Engels',
+      nl: 'Nederlands',
+      pap: 'Papiaments',
+    },
+  },
+};
+
+export const pap = {
+  LocalisedInput: {
+    Locales: {
+      en: 'Ingles',
+      nl: 'Hulandes',
+      pap: 'Papiamentu',
+    },
+  },
+};

--- a/app/components/LocalisedInput.tsx
+++ b/app/components/LocalisedInput.tsx
@@ -55,7 +55,7 @@ export default function LocalisedInput({
   function handleValueChange(event: SlChangeEvent) {
     setValue({
       ...value,
-      [currentLocale]: event.detail.value,
+      [currentLocale]: (event.target as HTMLInputElement)?.value,
     });
   }
 

--- a/app/components/LocalisedInput.tsx
+++ b/app/components/LocalisedInput.tsx
@@ -9,6 +9,7 @@ import {
 import { SlInputEventHandlers } from '~/types/Input';
 import { SupportedLanguages } from '~/config/i18n';
 import LocaleSelector from '~/components/LocaleSelector';
+import { ZodFormattedError } from 'zod';
 
 type Props = Omit<
   ComponentProps<ReactWebComponent<SlInputComponent>>,
@@ -21,7 +22,7 @@ type Props = Omit<
   | 'value'
 > &
   SlInputEventHandlers & {
-    errors?: Partial<Record<SupportedLanguages, string[]>>;
+    errors?: Partial<ZodFormattedError<Record<SupportedLanguages, string[]>>>;
     selectedLocale?: SupportedLanguages;
     value?: Partial<Record<SupportedLanguages, string>>;
   };
@@ -58,12 +59,18 @@ export default function LocalisedInput({
     });
   }
 
-  const currentLocaleHasError = !!errors?.[currentLocale]?.length;
-  const errorsExist = Object.values(errors ?? {}).some((error) => error.length);
+  const currentLocaleHasError = !!errors?.[currentLocale]?._errors.length;
+  const errorsExist = Object.values(errors ?? {}).some((error) => {
+    if (Array.isArray(error)) return false;
+
+    return error._errors.length;
+  });
   const errorsByLocale = Object.entries(errors ?? {}).reduce<
     Record<string, number>
   >((acc, [locale, error]) => {
-    acc[locale] = error.length;
+    if (Array.isArray(error)) return acc;
+
+    acc[locale] = error._errors.length;
     return acc;
   }, {});
 
@@ -75,8 +82,7 @@ export default function LocalisedInput({
           type="text"
           label={`${label} (${t(`Locales.${currentLocale}`)})`}
           id={id}
-          name={name}
-          className={`${className} ${currentLocaleHasError ? 'part-[base]:border-red-300' : ''}`}
+          className={`${className} ${currentLocaleHasError ? 'part-[base]:border-red-300' : ''} w-full`}
           value={value[currentLocale]}
           onSlChange={handleValueChange}
           aria-invalid={ariaInvalid}
@@ -91,7 +97,7 @@ export default function LocalisedInput({
         />
       </div>
       <SlAlert id={`${id}-error`} open={currentLocaleHasError} variant="danger">
-        {errors?.[currentLocale]?.join(', ')}
+        {errors?.[currentLocale]?._errors.join(', ')}
       </SlAlert>
       <input type="hidden" name={`${name}.nl`} value={value.nl} />
       <input type="hidden" name={`${name}.en`} value={value.en} />

--- a/app/components/LocalisedInput.tsx
+++ b/app/components/LocalisedInput.tsx
@@ -1,0 +1,101 @@
+import { ComponentProps, useContext, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ShoelaceContext } from '~/components/shoelace';
+import { ReactWebComponent } from '@lit/react';
+import {
+  SlChangeEvent,
+  SlInput as SlInputComponent,
+} from '@shoelace-style/shoelace';
+import { SlInputEventHandlers } from '~/types/Input';
+import { SupportedLanguages } from '~/config/i18n';
+import LocaleSelector from '~/components/LocaleSelector';
+
+type Props = Omit<
+  ComponentProps<ReactWebComponent<SlInputComponent>>,
+  | 'onSlBlur'
+  | 'onSlChange'
+  | 'onSlClear'
+  | 'onSlFocus'
+  | 'onSlInput'
+  | 'onSlInvalid'
+  | 'value'
+> &
+  SlInputEventHandlers & {
+    errors?: Partial<Record<SupportedLanguages, string[]>>;
+    selectedLocale?: SupportedLanguages;
+    value?: Partial<Record<SupportedLanguages, string>>;
+  };
+
+export default function LocalisedInput({
+  errors,
+  id = '',
+  name = '',
+  className = '',
+  'aria-invalid': ariaInvalid = !!errors,
+  selectedLocale = 'nl',
+  label = '',
+  ...inputProps
+}: Props) {
+  const { t } = useTranslation('LocalisedInput');
+  const { SlInput, SlAlert } = useContext(ShoelaceContext);
+
+  const [currentLocale, setCurrentLocale] =
+    useState<SupportedLanguages>(selectedLocale);
+  const [value, setValue] = useState<Record<SupportedLanguages, string>>({
+    nl: inputProps?.value?.nl ?? '',
+    en: inputProps?.value?.en ?? '',
+    pap: inputProps?.value?.pap ?? '',
+  });
+
+  function handleLocaleSelect(locale: SupportedLanguages) {
+    setCurrentLocale(locale);
+  }
+
+  function handleValueChange(event: SlChangeEvent) {
+    setValue({
+      ...value,
+      [currentLocale]: event.detail.value,
+    });
+  }
+
+  const currentLocaleHasError = !!errors?.[currentLocale]?.length;
+  const errorsExist = Object.values(errors ?? {}).some((error) => error.length);
+  const errorsByLocale = Object.entries(errors ?? {}).reduce<
+    Record<string, number>
+  >((acc, [locale, error]) => {
+    acc[locale] = error.length;
+    return acc;
+  }, {});
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-row gap-2 items-end">
+        <SlInput
+          {...inputProps}
+          type="text"
+          label={`${label} (${t(`Locales.${currentLocale}`)})`}
+          id={id}
+          name={name}
+          className={`${className} ${currentLocaleHasError ? 'part-[base]:border-red-300' : ''}`}
+          value={value[currentLocale]}
+          onSlChange={handleValueChange}
+          aria-invalid={ariaInvalid}
+          aria-describedby={errors ? `${id}-error` : undefined}
+        ></SlInput>
+        <LocaleSelector
+          captionType="none"
+          onLocaleSelect={handleLocaleSelect}
+          selectedLocale={currentLocale}
+          captionBadge={errorsExist ? '•' : undefined}
+          localeBadges={errorsByLocale}
+        />
+      </div>
+      <SlAlert id={`${id}-error`} open={currentLocaleHasError} variant="danger">
+        {errors?.[currentLocale]?.join(', ')}
+      </SlAlert>
+      <input type="hidden" name={`${name}.nl`} value={value.nl} />
+      <input type="hidden" name={`${name}.en`} value={value.en} />
+      <input type="hidden" name={`${name}.pap`} value={value.pap} />
+    </div>
+  );
+}

--- a/app/components/ProjectMutationForm.stories.tsx
+++ b/app/components/ProjectMutationForm.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { faker } from '@faker-js/faker';
 import ProjectMutationForm from './ProjectMutationForm';
+import { expect, screen } from '@storybook/test';
+import { validateProject } from '~/validations/models/project';
+import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 
 export default {
   title: 'Components/Project Mutation Form',
@@ -9,28 +12,57 @@ export default {
 
 type Story = StoryObj<typeof ProjectMutationForm>;
 
+const fakeProject = {
+  title: {
+    en: faker.lorem.words(),
+    nl: faker.lorem.words(),
+    pap: faker.lorem.words(),
+  },
+  description: {
+    en: faker.lorem.paragraph({ min: 2, max: 4 }),
+    nl: faker.lorem.paragraph({ min: 2, max: 4 }),
+    pap: faker.lorem.paragraph({ min: 2, max: 4 }),
+  },
+  summary: {
+    en: faker.lorem.paragraph(),
+    nl: faker.lorem.paragraph(),
+    pap: faker.lorem.paragraph(),
+  },
+  slug: faker.lorem.slug(),
+};
+
 export const EmptyForm: Story = {
   args: {},
 };
 
 export const FilledForm: Story = {
-  args: {
-    title: {
-      en: faker.lorem.words(),
-      nl: faker.lorem.words(),
-      pap: faker.lorem.words(),
-    },
-    description: {
-      en: faker.lorem.paragraphs({ min: 2, max: 5 }),
-      nl: faker.lorem.paragraphs({ min: 2, max: 5 }),
-      pap: faker.lorem.paragraphs({ min: 2, max: 5 }),
-    },
-    summary: {
-      en: faker.lorem.paragraph(),
-      nl: faker.lorem.paragraph(),
-      pap: faker.lorem.paragraph(),
-    },
-    slug: faker.lorem.slug(),
+  args: fakeProject,
+
+  play: async () => {
+    await screen.findByText('Save');
+    const form = (await screen.findByRole('form')) as HTMLFormElement;
+
+    const formData = new FormData(form);
+
+    await expect(formData.get('title.en')).toBe(fakeProject.title.en);
+    await expect(formData.get('title.nl')).toBe(fakeProject.title.nl);
+    await expect(formData.get('title.pap')).toBe(fakeProject.title.pap);
+
+    await expect(formData.get('description.en')).toBe(
+      fakeProject.description.en,
+    );
+    await expect(formData.get('description.nl')).toBe(
+      fakeProject.description.nl,
+    );
+    await expect(formData.get('description.pap')).toBe(
+      fakeProject.description.pap,
+    );
+
+    await expect(formData.get('summary.en')).toBe(fakeProject.summary.en);
+    await expect(formData.get('summary.nl')).toBe(fakeProject.summary.nl);
+    await expect(formData.get('summary.pap')).toBe(fakeProject.summary.pap);
+
+    await expect(formData.get('slug')).toBe(fakeProject.slug);
   },
 };
 
@@ -38,37 +70,34 @@ export const ErrorForm: Story = {
   args: {
     title: {
       en: faker.lorem.words(),
-      nl: faker.lorem.words(),
       pap: faker.lorem.words(),
     },
     description: {
-      en: faker.lorem.paragraphs({ min: 2, max: 5 }),
       nl: faker.lorem.paragraphs({ min: 2, max: 5 }),
       pap: faker.lorem.paragraphs({ min: 2, max: 5 }),
     },
     summary: {
       en: faker.lorem.paragraph(),
       nl: faker.lorem.paragraph(),
-      pap: faker.lorem.paragraph(),
     },
-    slug: faker.lorem.slug(),
   },
 
   parameters: {
-    reactRouter: {
+    reactRouter: reactRouterParameters({
       routing: {
         path: '/',
-        action: async () => {
-          return {
-            errors: {
-              title: ['Title is required'],
-              description: ['Description is required'],
-              summary: ['Summary is required'],
-              slug: ['Slug is required'],
-            },
-          };
+        action: async ({ request }) => {
+          return validateProject(request);
         },
       },
-    },
+    }),
+  },
+
+  play: async () => {
+    const submit = await screen.findByText('Save');
+
+    submit.click();
+
+    screen.findAllByText('String must contain at least 1 character(s)');
   },
 };

--- a/app/components/ProjectMutationForm.stories.tsx
+++ b/app/components/ProjectMutationForm.stories.tsx
@@ -1,0 +1,74 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { faker } from '@faker-js/faker';
+import ProjectMutationForm from './ProjectMutationForm';
+
+export default {
+  title: 'Components/Project Mutation Form',
+  component: ProjectMutationForm,
+} satisfies Meta<typeof ProjectMutationForm>;
+
+type Story = StoryObj<typeof ProjectMutationForm>;
+
+export const EmptyForm: Story = {
+  args: {},
+};
+
+export const FilledForm: Story = {
+  args: {
+    title: {
+      en: faker.lorem.words(),
+      nl: faker.lorem.words(),
+      pap: faker.lorem.words(),
+    },
+    description: {
+      en: faker.lorem.paragraphs({ min: 2, max: 5 }),
+      nl: faker.lorem.paragraphs({ min: 2, max: 5 }),
+      pap: faker.lorem.paragraphs({ min: 2, max: 5 }),
+    },
+    summary: {
+      en: faker.lorem.paragraph(),
+      nl: faker.lorem.paragraph(),
+      pap: faker.lorem.paragraph(),
+    },
+    slug: faker.lorem.slug(),
+  },
+};
+
+export const ErrorForm: Story = {
+  args: {
+    title: {
+      en: faker.lorem.words(),
+      nl: faker.lorem.words(),
+      pap: faker.lorem.words(),
+    },
+    description: {
+      en: faker.lorem.paragraphs({ min: 2, max: 5 }),
+      nl: faker.lorem.paragraphs({ min: 2, max: 5 }),
+      pap: faker.lorem.paragraphs({ min: 2, max: 5 }),
+    },
+    summary: {
+      en: faker.lorem.paragraph(),
+      nl: faker.lorem.paragraph(),
+      pap: faker.lorem.paragraph(),
+    },
+    slug: faker.lorem.slug(),
+  },
+
+  parameters: {
+    reactRouter: {
+      routing: {
+        path: '/',
+        action: async () => {
+          return {
+            errors: {
+              title: ['Title is required'],
+              description: ['Description is required'],
+              summary: ['Summary is required'],
+              slug: ['Slug is required'],
+            },
+          };
+        },
+      },
+    },
+  },
+};

--- a/app/components/ProjectMutationForm.translations.ts
+++ b/app/components/ProjectMutationForm.translations.ts
@@ -1,0 +1,35 @@
+export const en = {
+  ProjectMutationForm: {
+    Title: 'New project',
+    Labels: {
+      Title: 'Title',
+      Description: 'Description',
+      Summary: 'Summary',
+      Slug: 'Slug',
+    },
+  },
+};
+
+export const nl = {
+  ProjectMutationForm: {
+    Title: 'Nieuw project',
+    Labels: {
+      Title: 'Titel',
+      Description: 'Beschrijving',
+      Summary: 'Samenvatting',
+      Slug: 'Slug',
+    },
+  },
+};
+
+export const pap = {
+  ProjectMutationForm: {
+    Title: 'Proyek nobo',
+    Labels: {
+      Title: 'Título',
+      Description: 'Deskripshon',
+      Summary: 'Resumen',
+      Slug: 'Slug',
+    },
+  },
+};

--- a/app/components/ProjectMutationForm.translations.ts
+++ b/app/components/ProjectMutationForm.translations.ts
@@ -1,6 +1,9 @@
 export const en = {
   ProjectMutationForm: {
-    Title: 'New project',
+    Title: {
+      New: 'New project',
+      Edit: 'Edit project',
+    },
     Labels: {
       Title: 'Title',
       Description: 'Description',
@@ -12,7 +15,10 @@ export const en = {
 
 export const nl = {
   ProjectMutationForm: {
-    Title: 'Nieuw project',
+    Title: {
+      New: 'Nieuw project',
+      Edit: 'Bewerk project',
+    },
     Labels: {
       Title: 'Titel',
       Description: 'Beschrijving',
@@ -24,7 +30,10 @@ export const nl = {
 
 export const pap = {
   ProjectMutationForm: {
-    Title: 'Proyek nobo',
+    Title: {
+      New: 'Proyek nobo',
+      Edit: 'Edita proyek',
+    },
     Labels: {
       Title: 'Título',
       Description: 'Deskripshon',

--- a/app/components/ProjectMutationForm.tsx
+++ b/app/components/ProjectMutationForm.tsx
@@ -1,39 +1,42 @@
 import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useFetcher } from 'react-router';
+import { Project } from '~/models/projects.server';
 import { ShoelaceContext } from '~/components/shoelace';
+import { useFetcher } from 'react-router';
+import { ProjectErrors } from '~/validations/models/project';
 import Heading from '~/components/Heading';
-import { Event } from '~/models/events.server';
 import Input from '~/components/Input';
-import { EventErrors } from '~/validations/models/event';
 
-type Props = Partial<Omit<Event, 'id' | 'createdAt' | 'updatedAt'>> & {
+type Props = Partial<Omit<Project, 'id' | 'createdAt' | 'updatedAt'>> & {
   id?: string;
 };
 
-export default function EventForm({
+export default function ProjectMutationForm({
   id = '',
   title,
   description,
-  link = '',
-  address = '',
-  eventDate,
+  summary,
+  slug = '',
 }: Props) {
-  const { t, i18n } = useTranslation('EventForm');
+  const { t, i18n } = useTranslation('ProjectMutationForm');
   const { SlButton } = useContext(ShoelaceContext);
   const fetcher = useFetcher();
 
   const localisedTitle = title ? title[i18n.language] : '';
   const localisedDescription = description ? description[i18n.language] : '';
+  const localisedSummary = summary ? summary[i18n.language] : '';
 
-  const errors = fetcher.data?.errors as EventErrors;
+  const errors = fetcher.data?.errors as ProjectErrors;
   const isSubmitting = fetcher.state !== 'idle';
 
   return (
     <fetcher.Form className="space-y-4" method="post">
       <Heading level={1}>{t('Title')}</Heading>
 
-      <input type="hidden" name="id" value={id} />
+      {id ?
+        <input type="hidden" name="id" value={id} />
+      : null}
+
       <Input
         label={t('Labels.Title')}
         name="title"
@@ -53,30 +56,21 @@ export default function EventForm({
       />
 
       <Input
-        label={t('Labels.Address')}
-        name="address"
-        id="address"
+        label={t('Labels.Summary')}
+        name="summary"
+        id="summary"
         type="text"
-        value={address}
-        error={errors?.address}
+        value={localisedSummary}
+        error={errors?.summary}
       />
 
       <Input
-        label={t('Labels.Link')}
-        id="link"
-        name="link"
-        type="url"
-        value={link}
-        error={errors?.link}
-      />
-
-      <Input
-        label={t('Labels.EventDate')}
-        name="eventDate"
-        id="eventDate"
-        type="datetime-local"
-        defaultValue={eventDate?.toISOString()}
-        error={errors?.eventDate}
+        label={t('Labels.Slug')}
+        name="slug"
+        id="slug"
+        type="text"
+        value={slug}
+        error={errors?.slug}
       />
 
       <div className="flex justify-end">

--- a/app/components/ProjectMutationForm.tsx
+++ b/app/components/ProjectMutationForm.tsx
@@ -25,10 +25,15 @@ export default function ProjectMutationForm({
   const errors = fetcher.data?.errors;
   const content = fetcher.data?.data || initialValues;
 
+  let titleTranslationKey = 'Title.New';
+  if (id) {
+    titleTranslationKey = 'Title.Edit';
+  }
+
   return (
     <fetcher.Form name="project-form" className="space-y-4" method="post">
       <div className="flex flex-row justify-between items-center">
-        <Heading level={1}>{t('Title')}</Heading>
+        <Heading level={1}>{t(titleTranslationKey)}</Heading>
       </div>
 
       {id ?

--- a/app/components/ProjectMutationForm.tsx
+++ b/app/components/ProjectMutationForm.tsx
@@ -1,14 +1,15 @@
-import { useContext, useEffect, useState } from 'react';
+import { useContext } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Project } from '~/models/projects.server';
 import { ShoelaceContext } from '~/components/shoelace';
 import { useFetcher } from 'react-router';
 import { ProjectErrors, ProjectValidator } from '~/validations/models/project';
 import Heading from '~/components/Heading';
 import Input from '~/components/Input';
 import { ErrorResponse } from '~/types/Validations';
+import LocalisedInput from '~/components/LocalisedInput';
+import { DeepPartial } from '~/types/DeepPartial';
 
-type Props = Partial<Omit<Project, 'id' | 'createdAt' | 'updatedAt'>> & {
+type Props = DeepPartial<ProjectValidator> & {
   id?: string;
 };
 
@@ -16,66 +17,46 @@ export default function ProjectMutationForm({
   id = '',
   ...initialValues
 }: Props) {
-  const { t, i18n } = useTranslation('ProjectMutationForm');
+  const { t } = useTranslation('ProjectMutationForm');
   const { SlButton } = useContext(ShoelaceContext);
   const fetcher = useFetcher<ErrorResponse<ProjectErrors, ProjectValidator>>();
 
-  const [title, setTitle] = useState(
-    initialValues.title ? initialValues.title[i18n.language] : '',
-  );
-  const [description, setDescription] = useState(
-    initialValues.description ? initialValues.description[i18n.language] : '',
-  );
-  const [summary, setSummary] = useState(
-    initialValues.summary ? initialValues.summary[i18n.language] : '',
-  );
-  const [slug, setSlug] = useState(initialValues.slug ?? '');
-
-  useEffect(() => {
-    if (fetcher.data) {
-      const { title, description, summary, slug } = fetcher.data.data;
-      setTitle(title);
-      setDescription(description);
-      setSummary(summary);
-      setSlug(slug);
-    }
-  }, [fetcher.data, i18n.language]);
-  const errors = fetcher.data?.errors as ProjectErrors;
   const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+  const content = fetcher.data?.data || initialValues;
 
   return (
-    <fetcher.Form className="space-y-4" method="post">
-      <Heading level={1}>{t('Title')}</Heading>
+    <fetcher.Form name="project-form" className="space-y-4" method="post">
+      <div className="flex flex-row justify-between items-center">
+        <Heading level={1}>{t('Title')}</Heading>
+      </div>
 
       {id ?
         <input type="hidden" name="id" value={id} />
       : null}
 
-      <Input
+      <LocalisedInput
         label={t('Labels.Title')}
         name="title"
         id="title"
-        type="text"
-        value={title}
-        error={errors?.title}
+        value={content?.title}
+        errors={errors?.title}
       />
 
-      <Input
+      <LocalisedInput
         label={t('Labels.Description')}
         name="description"
         id="description"
-        type="text"
-        value={description}
-        error={errors?.description}
+        value={content?.description}
+        errors={errors?.description}
       />
 
-      <Input
+      <LocalisedInput
         label={t('Labels.Summary')}
         name="summary"
         id="summary"
-        type="text"
-        value={summary}
-        error={errors?.summary}
+        value={content?.summary}
+        errors={errors?.summary}
       />
 
       <Input
@@ -83,8 +64,8 @@ export default function ProjectMutationForm({
         name="slug"
         id="slug"
         type="text"
-        value={slug}
-        error={errors?.slug}
+        value={content?.slug || ''}
+        error={errors?.slug?._errors}
       />
 
       <div className="flex justify-end">

--- a/app/components/ProjectMutationForm.tsx
+++ b/app/components/ProjectMutationForm.tsx
@@ -1,11 +1,12 @@
-import { useContext } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Project } from '~/models/projects.server';
 import { ShoelaceContext } from '~/components/shoelace';
 import { useFetcher } from 'react-router';
-import { ProjectErrors } from '~/validations/models/project';
+import { ProjectErrors, ProjectValidator } from '~/validations/models/project';
 import Heading from '~/components/Heading';
 import Input from '~/components/Input';
+import { ErrorResponse } from '~/types/Validations';
 
 type Props = Partial<Omit<Project, 'id' | 'createdAt' | 'updatedAt'>> & {
   id?: string;
@@ -13,19 +14,32 @@ type Props = Partial<Omit<Project, 'id' | 'createdAt' | 'updatedAt'>> & {
 
 export default function ProjectMutationForm({
   id = '',
-  title,
-  description,
-  summary,
-  slug = '',
+  ...initialValues
 }: Props) {
   const { t, i18n } = useTranslation('ProjectMutationForm');
   const { SlButton } = useContext(ShoelaceContext);
-  const fetcher = useFetcher();
+  const fetcher = useFetcher<ErrorResponse<ProjectErrors, ProjectValidator>>();
 
-  const localisedTitle = title ? title[i18n.language] : '';
-  const localisedDescription = description ? description[i18n.language] : '';
-  const localisedSummary = summary ? summary[i18n.language] : '';
+  const [title, setTitle] = useState(
+    initialValues.title ? initialValues.title[i18n.language] : '',
+  );
+  const [description, setDescription] = useState(
+    initialValues.description ? initialValues.description[i18n.language] : '',
+  );
+  const [summary, setSummary] = useState(
+    initialValues.summary ? initialValues.summary[i18n.language] : '',
+  );
+  const [slug, setSlug] = useState(initialValues.slug ?? '');
 
+  useEffect(() => {
+    if (fetcher.data) {
+      const { title, description, summary, slug } = fetcher.data.data;
+      setTitle(title);
+      setDescription(description);
+      setSummary(summary);
+      setSlug(slug);
+    }
+  }, [fetcher.data, i18n.language]);
   const errors = fetcher.data?.errors as ProjectErrors;
   const isSubmitting = fetcher.state !== 'idle';
 
@@ -42,7 +56,7 @@ export default function ProjectMutationForm({
         name="title"
         id="title"
         type="text"
-        value={localisedTitle}
+        value={title}
         error={errors?.title}
       />
 
@@ -51,7 +65,7 @@ export default function ProjectMutationForm({
         name="description"
         id="description"
         type="text"
-        value={localisedDescription}
+        value={description}
         error={errors?.description}
       />
 
@@ -60,7 +74,7 @@ export default function ProjectMutationForm({
         name="summary"
         id="summary"
         type="text"
-        value={localisedSummary}
+        value={summary}
         error={errors?.summary}
       />
 

--- a/app/components/shoelace.ts
+++ b/app/components/shoelace.ts
@@ -10,6 +10,9 @@ import {
   SlDrawer,
   SlIconButton,
   SlDialog,
+  SlDropdown,
+  SlMenu,
+  SlMenuItem,
 } from '@shoelace-style/shoelace/dist/react';
 import { useEffect, useState, useRef, createContext } from 'react';
 
@@ -27,6 +30,9 @@ type Components = {
   SlDrawer: typeof nullComponent | typeof SlDrawer;
   SlIconButton: typeof nullComponent | typeof SlIconButton;
   SlDialog: typeof nullComponent | typeof SlDialog;
+  SlDropdown: typeof nullComponent | typeof SlDropdown;
+  SlMenu: typeof nullComponent | typeof SlMenu;
+  SlMenuItem: typeof nullComponent | typeof SlMenuItem;
 };
 
 const nullComponents: Components = {
@@ -41,6 +47,9 @@ const nullComponents: Components = {
   SlDrawer: nullComponent,
   SlIconButton: nullComponent,
   SlDialog: nullComponent,
+  SlDropdown: nullComponent,
+  SlMenu: nullComponent,
+  SlMenuItem: nullComponent,
 };
 
 export const ShoelaceContext = createContext<Components>(nullComponents);
@@ -72,6 +81,9 @@ export function useShoelace({ URL }: { URL: string }) {
             SlDrawer: components.SlDrawer,
             SlIconButton: components.SlIconButton,
             SlDialog: components.SlDialog,
+            SlDropdown: components.SlDropdown,
+            SlMenu: components.SlMenu,
+            SlMenuItem: components.SlMenuItem,
           });
         });
       },

--- a/app/components/shoelace.ts
+++ b/app/components/shoelace.ts
@@ -13,6 +13,7 @@ import {
   SlDropdown,
   SlMenu,
   SlMenuItem,
+  SlBadge,
 } from '@shoelace-style/shoelace/dist/react';
 import { useEffect, useState, useRef, createContext } from 'react';
 
@@ -33,6 +34,7 @@ type Components = {
   SlDropdown: typeof nullComponent | typeof SlDropdown;
   SlMenu: typeof nullComponent | typeof SlMenu;
   SlMenuItem: typeof nullComponent | typeof SlMenuItem;
+  SlBadge: typeof nullComponent | typeof SlBadge;
 };
 
 const nullComponents: Components = {
@@ -50,6 +52,7 @@ const nullComponents: Components = {
   SlDropdown: nullComponent,
   SlMenu: nullComponent,
   SlMenuItem: nullComponent,
+  SlBadge: nullComponent,
 };
 
 export const ShoelaceContext = createContext<Components>(nullComponents);
@@ -84,6 +87,7 @@ export function useShoelace({ URL }: { URL: string }) {
             SlDropdown: components.SlDropdown,
             SlMenu: components.SlMenu,
             SlMenuItem: components.SlMenuItem,
+            SlBadge: components.SlBadge,
           });
         });
       },

--- a/app/config/i18n.ts
+++ b/app/config/i18n.ts
@@ -8,7 +8,7 @@ import { FormatFunction } from 'i18next';
 // List of supported languages, where NL is the default language.
 export const supportedLanguages = ['en', 'pap', 'nl'];
 
-export type SupportedLanguages = (typeof supportedLanguages)[number];
+export type SupportedLanguages = 'en' | 'pap' | 'nl';
 
 // Fallback language if somehow the detected language is not supported.
 export const fallbackLanguage = 'nl';

--- a/app/config/i18n.ts
+++ b/app/config/i18n.ts
@@ -3,6 +3,7 @@ import { serverOnly$ } from 'vite-env-only/macros';
 import * as englishBundle from '~/locales/en';
 import * as dutchBundle from '~/locales/nl';
 import * as papiamentuBundle from '~/locales/pap';
+import { FormatFunction } from 'i18next';
 
 // List of supported languages, where NL is the default language.
 export const supportedLanguages = ['en', 'pap', 'nl'];
@@ -19,3 +20,28 @@ export const resources = serverOnly$({
   nl: dutchBundle,
   pap: papiamentuBundle,
 });
+
+type Formatter = {
+  name: string;
+  func: FormatFunction;
+};
+export const formatters: Formatter[] = [
+  {
+    name: 'lowercase',
+    func: (value: string) => {
+      return value.toLowerCase();
+    },
+  },
+  {
+    name: 'uppercase',
+    func: (value: string) => {
+      return value.toUpperCase();
+    },
+  },
+  {
+    name: 'capitalize',
+    func: (value: string) => {
+      return value.charAt(0).toUpperCase() + value.slice(1);
+    },
+  },
+];

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -6,7 +6,12 @@ import { startTransition, StrictMode } from 'react';
 import { hydrateRoot } from 'react-dom/client';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { getInitialNamespaces } from 'remix-i18next/client';
-import { defaultNS, fallbackLanguage, supportedLanguages } from '~/config/i18n';
+import {
+  defaultNS,
+  fallbackLanguage,
+  supportedLanguages,
+  formatters,
+} from '~/config/i18n';
 
 async function main() {
   // eslint-disable-next-line import/no-named-as-default-member
@@ -35,10 +40,9 @@ async function main() {
       },
     });
 
-  // TODO: Enable this when i18next is updated to latest
-  // i18n.formatters.forEach((formatter) => {
-  //   i18next.services.formatter?.add(formatter.name, formatter.func);
-  // });
+  formatters.forEach((formatter) => {
+    i18next.services.formatter?.add(formatter.name, formatter.func);
+  });
 
   startTransition(() => {
     hydrateRoot(

--- a/app/entry.client.tsx
+++ b/app/entry.client.tsx
@@ -35,6 +35,11 @@ async function main() {
       },
     });
 
+  // TODO: Enable this when i18next is updated to latest
+  // i18n.formatters.forEach((formatter) => {
+  //   i18next.services.formatter?.add(formatter.name, formatter.func);
+  // });
+
   startTransition(() => {
     hydrateRoot(
       document,

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -27,6 +27,10 @@ export default async function handleRequest(
   const ns = i18nServer.getRouteNamespaces(reactRouterContext);
 
   await instance.use(initReactI18next).init({ ...i18n, lng, ns });
+  // TODO: Enable this when i18next is updated to latest
+  // i18n.formatters.forEach((formatter) => {
+  //   instance.services.formatter?.add(formatter.name, formatter.func);
+  // });
 
   return isbot(request.headers.get('user-agent') || '') ?
       handleBotRequest(

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -131,9 +131,31 @@ export const NewsOverviewRoute = {
   Title: 'News',
 };
 
+export const ContentTypes = {
+  // These use the content type as defined in the URLs
+  evenementen_one: 'Event',
+  evenementen_other: 'Events',
+  projecten_one: 'Project',
+  projecten_other: 'Projects',
+};
+
 export const ContentOverviewRoute = {
   Titles: {
     events: 'Events',
     projects: 'Projects',
   },
+};
+
+export const NewContentRoute = {
+  Meta: {
+    Title: 'New $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
+  },
+  Title: 'New $t(ContentTypes:{{content}}, lowercase)',
+};
+
+export const EditContentRoute = {
+  Meta: {
+    Title: 'Edit $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
+  },
+  Title: 'Edit $t(ContentTypes:{{content}}, lowercase)',
 };

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -20,8 +20,10 @@ import { en as ConfirmDeleteDialogTranslations } from '~/routes/($lang)/beheer/$
 export const { ConfirmDeleteDialog } = ConfirmDeleteDialogTranslations;
 import { en as DeletionNotificationTranslations } from '~/routes/($lang)/beheer/$content/_index/DeletionNotification.translations';
 export const { DeletionNotification } = DeletionNotificationTranslations;
-import { en as EventFormTranslations } from '~/components/EventForm.translations';
-export const { EventForm } = EventFormTranslations;
+import { en as EventFormTranslations } from '~/components/EventMutationForm.translations';
+export const { EventMutationForm } = EventFormTranslations;
+import { en as ProjectFormTranslations } from '~/components/ProjectMutationForm.translations';
+export const { ProjectMutationForm } = ProjectFormTranslations;
 
 export const common = {
   title: 'Hello World!',

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -156,12 +156,10 @@ export const NewContentRoute = {
   Meta: {
     Title: 'New $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
   },
-  Title: 'New $t(ContentTypes:{{content}}, lowercase)',
 };
 
 export const EditContentRoute = {
   Meta: {
     Title: 'Edit $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
   },
-  Title: 'Edit $t(ContentTypes:{{content}}, lowercase)',
 };

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -140,10 +140,12 @@ export const ContentTypes = {
 };
 
 export const ContentOverviewRoute = {
-  Titles: {
-    events: 'Events',
-    projects: 'Projects',
+  ...ContentTypes,
+  Meta: {
+    Title: 'Admin - $t({{content}}, lowercase) | Stichting Watershed',
   },
+  Title: '$t({{content}}, capitalize)',
+  NewButtonCaption: 'New $t({{content}}, lowercase)',
 };
 
 export const NewContentRoute = {

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -24,6 +24,8 @@ import { en as EventFormTranslations } from '~/components/EventMutationForm.tran
 export const { EventMutationForm } = EventFormTranslations;
 import { en as ProjectFormTranslations } from '~/components/ProjectMutationForm.translations';
 export const { ProjectMutationForm } = ProjectFormTranslations;
+import { en as LocaleSelectorTranslations } from '~/components/LocaleSelector.translations';
+export const { LocaleSelector } = LocaleSelectorTranslations;
 
 export const common = {
   title: 'Hello World!',

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -20,6 +20,8 @@ import { en as ConfirmDeleteDialogTranslations } from '~/routes/($lang)/beheer/$
 export const { ConfirmDeleteDialog } = ConfirmDeleteDialogTranslations;
 import { en as DeletionNotificationTranslations } from '~/routes/($lang)/beheer/$content/_index/DeletionNotification.translations';
 export const { DeletionNotification } = DeletionNotificationTranslations;
+import { en as EventFormTranslations } from '~/components/EventForm.translations';
+export const { EventForm } = EventFormTranslations;
 
 export const common = {
   title: 'Hello World!',

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -26,6 +26,8 @@ import { en as ProjectFormTranslations } from '~/components/ProjectMutationForm.
 export const { ProjectMutationForm } = ProjectFormTranslations;
 import { en as LocaleSelectorTranslations } from '~/components/LocaleSelector.translations';
 export const { LocaleSelector } = LocaleSelectorTranslations;
+import { en as LocalisedInputTranslations } from '~/components/LocalisedInput.translations';
+export const { LocalisedInput } = LocalisedInputTranslations;
 
 export const common = {
   title: 'Hello World!',

--- a/app/locales/nl.ts
+++ b/app/locales/nl.ts
@@ -26,6 +26,8 @@ import { nl as ProjectFormTranslations } from '~/components/ProjectMutationForm.
 export const { ProjectMutationForm } = ProjectFormTranslations;
 import { nl as LocaleSelectorTranslations } from '~/components/LocaleSelector.translations';
 export const { LocaleSelector } = LocaleSelectorTranslations;
+import { nl as LocalisedInputTranslations } from '~/components/LocalisedInput.translations';
+export const { LocalisedInput } = LocalisedInputTranslations;
 
 export const common = {
   title: 'Hallo Wereld!',

--- a/app/locales/nl.ts
+++ b/app/locales/nl.ts
@@ -20,8 +20,10 @@ import { nl as ConfirmDeleteDialogTranslations } from '~/routes/($lang)/beheer/$
 export const { ConfirmDeleteDialog } = ConfirmDeleteDialogTranslations;
 import { nl as DeletionNotificationTranslations } from '~/routes/($lang)/beheer/$content/_index/DeletionNotification.translations';
 export const { DeletionNotification } = DeletionNotificationTranslations;
-import { nl as EventFormTranslations } from '~/components/EventForm.translations';
-export const { EventForm } = EventFormTranslations;
+import { nl as EventFormTranslations } from '~/components/EventMutationForm.translations';
+export const { EventMutationForm } = EventFormTranslations;
+import { nl as ProjectFormTranslations } from '~/components/ProjectMutationForm.translations';
+export const { ProjectMutationForm } = ProjectFormTranslations;
 
 export const common = {
   title: 'Hallo Wereld!',

--- a/app/locales/nl.ts
+++ b/app/locales/nl.ts
@@ -158,7 +158,6 @@ export const NewContentRoute = {
     Title:
       'Nieuw $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
   },
-  Title: 'Nieuw $t(ContentTypes:{{content}}, lowercase)',
 };
 
 export const EditContentRoute = {
@@ -166,5 +165,4 @@ export const EditContentRoute = {
     Title:
       'Bewerk $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
   },
-  Title: 'Bewerk $t(ContentTypes:{{content}}, lowercase)',
 };

--- a/app/locales/nl.ts
+++ b/app/locales/nl.ts
@@ -132,9 +132,37 @@ export const NewsOverviewRoute = {
   Title: 'Nieuws',
 };
 
+export const ContentTypes = {
+  // These use the content type as defined in the URLs
+  evenementen_one: 'Evenement',
+  evenementen_other: 'Evenementen',
+  projecten_one: 'Project',
+  projecten_other: 'Projecten',
+};
+
 export const ContentOverviewRoute = {
+  Meta: {
+    Title:
+      'Beheer - $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
+  },
   Titles: {
     events: 'Evenementen',
     projects: 'Projecten',
   },
+};
+
+export const NewContentRoute = {
+  Meta: {
+    Title:
+      'Nieuw $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
+  },
+  Title: 'Nieuw $t(ContentTypes:{{content}}, lowercase)',
+};
+
+export const EditContentRoute = {
+  Meta: {
+    Title:
+      'Bewerk $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
+  },
+  Title: 'Bewerk $t(ContentTypes:{{content}}, lowercase)',
 };

--- a/app/locales/nl.ts
+++ b/app/locales/nl.ts
@@ -24,6 +24,8 @@ import { nl as EventFormTranslations } from '~/components/EventMutationForm.tran
 export const { EventMutationForm } = EventFormTranslations;
 import { nl as ProjectFormTranslations } from '~/components/ProjectMutationForm.translations';
 export const { ProjectMutationForm } = ProjectFormTranslations;
+import { nl as LocaleSelectorTranslations } from '~/components/LocaleSelector.translations';
+export const { LocaleSelector } = LocaleSelectorTranslations;
 
 export const common = {
   title: 'Hallo Wereld!',

--- a/app/locales/nl.ts
+++ b/app/locales/nl.ts
@@ -141,14 +141,12 @@ export const ContentTypes = {
 };
 
 export const ContentOverviewRoute = {
+  ...ContentTypes,
   Meta: {
-    Title:
-      'Beheer - $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
+    Title: 'Beheer - $t({{content}}, lowercase) | Stichting Watershed',
   },
-  Titles: {
-    events: 'Evenementen',
-    projects: 'Projecten',
-  },
+  Title: '$t({{content}}, capitalize)',
+  NewButtonCaption: 'Nieuw $t({{content}}, {"count": {{count}} })',
 };
 
 export const NewContentRoute = {

--- a/app/locales/nl.ts
+++ b/app/locales/nl.ts
@@ -20,6 +20,8 @@ import { nl as ConfirmDeleteDialogTranslations } from '~/routes/($lang)/beheer/$
 export const { ConfirmDeleteDialog } = ConfirmDeleteDialogTranslations;
 import { nl as DeletionNotificationTranslations } from '~/routes/($lang)/beheer/$content/_index/DeletionNotification.translations';
 export const { DeletionNotification } = DeletionNotificationTranslations;
+import { nl as EventFormTranslations } from '~/components/EventForm.translations';
+export const { EventForm } = EventFormTranslations;
 
 export const common = {
   title: 'Hallo Wereld!',

--- a/app/models/events.server.ts
+++ b/app/models/events.server.ts
@@ -1,6 +1,7 @@
 import { Event } from '@prisma/client';
 import { prisma } from '~/.server/db';
 import { type ContentTableItem } from '~/components/ContentTable';
+import { EventValidator } from '~/validations/models/event';
 
 export type { Event };
 
@@ -10,6 +11,10 @@ export async function getEvents(): Promise<Event[]> {
 
 export async function deleteEvent(eventID: string): Promise<void> {
   await prisma.event.delete({ where: { id: eventID } });
+}
+
+export async function saveEvent(event: EventValidator): Promise<Event> {
+  return prisma.event.create({ data: event });
 }
 
 export function convertEventsToTableData(events: Event[]): ContentTableItem[] {

--- a/app/models/events.server.ts
+++ b/app/models/events.server.ts
@@ -9,12 +9,23 @@ export async function getEvents(): Promise<Event[]> {
   return prisma.event.findMany();
 }
 
+export async function getEvent(eventID: string): Promise<Event> {
+  return prisma.event.findUniqueOrThrow({ where: { id: eventID } });
+}
+
 export async function deleteEvent(eventID: string): Promise<void> {
   await prisma.event.delete({ where: { id: eventID } });
 }
 
 export async function saveEvent(event: EventValidator): Promise<Event> {
   return prisma.event.create({ data: event });
+}
+
+export async function updateEvent(
+  eventID: string,
+  event: EventValidator,
+): Promise<Event> {
+  return prisma.event.update({ where: { id: eventID }, data: event });
 }
 
 export function convertEventsToTableData(events: Event[]): ContentTableItem[] {

--- a/app/models/projects.server.ts
+++ b/app/models/projects.server.ts
@@ -9,12 +9,23 @@ export async function getProjects(): Promise<Project[]> {
   return prisma.project.findMany();
 }
 
+export async function getProject(projectID: string): Promise<Project> {
+  return prisma.project.findUniqueOrThrow({ where: { id: projectID } });
+}
+
 export async function deleteProject(projectID: string): Promise<void> {
   await prisma.project.delete({ where: { id: projectID } });
 }
 
 export async function saveProject(project: ProjectValidator): Promise<Project> {
   return prisma.project.create({ data: project });
+}
+
+export async function updateProject(
+  projectID: string,
+  project: ProjectValidator,
+): Promise<Project> {
+  return prisma.project.update({ where: { id: projectID }, data: project });
 }
 
 export function convertProjectsToTableData(

--- a/app/models/projects.server.ts
+++ b/app/models/projects.server.ts
@@ -1,6 +1,7 @@
 import { Project } from '@prisma/client';
 import { prisma } from '~/.server/db';
 import type { ContentTableItem } from '~/components/ContentTable';
+import { ProjectValidator } from '~/validations/models/project';
 
 export type { Project };
 
@@ -10,6 +11,10 @@ export async function getProjects(): Promise<Project[]> {
 
 export async function deleteProject(projectID: string): Promise<void> {
   await prisma.project.delete({ where: { id: projectID } });
+}
+
+export async function saveProject(project: ProjectValidator): Promise<Project> {
+  return prisma.project.create({ data: project });
 }
 
 export function convertProjectsToTableData(

--- a/app/modules/i18n.server.ts
+++ b/app/modules/i18n.server.ts
@@ -2,6 +2,7 @@ import { createCookie } from 'react-router';
 import { RemixI18Next } from 'remix-i18next/server';
 
 import * as i18n from '~/config/i18n';
+import { FormatFunction } from 'i18next';
 
 export const localeCookie = createCookie('locale', {
   path: '/',
@@ -27,5 +28,23 @@ export default new RemixI18Next({
   },
   i18next: {
     ...i18n,
+    interpolation: {
+      format: (value, format) => {
+        // TODO: Remove this when i18n is updated to latest
+        if (format) {
+          const { formatters } = i18n;
+
+          const formatterFunc: FormatFunction | undefined = formatters.find(
+            (formatter) => formatter.name === format,
+          )?.func;
+
+          if (formatterFunc) {
+            return formatterFunc(value);
+          }
+        }
+
+        return value;
+      },
+    },
   },
 });

--- a/app/routes/($lang)/beheer/$content/_index/_overview.tsx
+++ b/app/routes/($lang)/beheer/$content/_index/_overview.tsx
@@ -10,10 +10,11 @@ import { ContentURLParams } from '~/types/Content';
 import { useTranslation } from 'react-i18next';
 import Heading from '~/components/Heading';
 import ConfirmDeleteDialog from '~/routes/($lang)/beheer/$content/_index/ConfirmDeleteDialog';
-import { useRef, useState } from 'react';
+import { useContext, useRef, useState } from 'react';
 import DeletionNotification from '~/routes/($lang)/beheer/$content/_index/DeletionNotification';
 import { SlAlert } from '@shoelace-style/shoelace';
 import i18nServer from '~/modules/i18n.server';
+import { ShoelaceContext } from '~/components/shoelace';
 
 export async function loader({ params, request }: Route.LoaderArgs) {
   const content = params.content as ContentURLParams;
@@ -53,6 +54,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export default function ContentOverviewRoute({ params }: Route.ComponentProps) {
   const content = params.content as ContentURLParams;
+  const { SlButton, SlIcon } = useContext(ShoelaceContext);
   const { data } = useLoaderData<typeof loader>();
   const fetcher = useFetcher();
   const { t } = useTranslation('ContentOverviewRoute');
@@ -61,18 +63,6 @@ export default function ContentOverviewRoute({ params }: Route.ComponentProps) {
   const notifyRef = useRef<SlAlert>(null);
   const [itemName, setItemName] = useState('asd');
   const [itemID, setItemID] = useState('asd');
-
-  let translationKey = '';
-  switch (content) {
-    case 'evenementen': {
-      translationKey = 'Titles.events';
-      break;
-    }
-    case 'projecten': {
-      translationKey = 'Titles.projects';
-      break;
-    }
-  }
 
   function triggerDelete(itemID: string, itemName: string) {
     setItemName(itemName);
@@ -107,8 +97,15 @@ export default function ContentOverviewRoute({ params }: Route.ComponentProps) {
   const isDeleting = fetcher.state !== 'idle';
 
   return (
-    <div>
-      <Heading level={1}>{t(translationKey)}</Heading>
+    <div className="space-y-4">
+      <div className="flex flex-row justify-between items-center">
+        <Heading level={1}>{t('Title', { content })}</Heading>
+        <SlButton href={`/beheer/${content}/nieuw`} variant="primary">
+          <SlIcon slot="prefix" name="plus-circle-dotted"></SlIcon>
+          {t('NewButtonCaption', { content, count: 1 })}
+        </SlButton>
+      </div>
+
       <ContentTable items={data} triggerDelete={triggerDelete} />
 
       <ConfirmDeleteDialog

--- a/app/routes/($lang)/beheer/$content/_index/_overview.tsx
+++ b/app/routes/($lang)/beheer/$content/_index/_overview.tsx
@@ -13,9 +13,11 @@ import ConfirmDeleteDialog from '~/routes/($lang)/beheer/$content/_index/Confirm
 import { useRef, useState } from 'react';
 import DeletionNotification from '~/routes/($lang)/beheer/$content/_index/DeletionNotification';
 import { SlAlert } from '@shoelace-style/shoelace';
+import i18nServer from '~/modules/i18n.server';
 
-export async function loader({ params }: Route.LoaderArgs) {
+export async function loader({ params, request }: Route.LoaderArgs) {
   const content = params.content as ContentURLParams;
+  const t = await i18nServer.getFixedT(request, 'ContentOverviewRoute');
 
   let data: ContentTableItem[] = [];
 
@@ -33,8 +35,21 @@ export async function loader({ params }: Route.LoaderArgs) {
     }
   }
 
-  return { data };
+  return {
+    data,
+    metaTranslations: {
+      title: t('Meta.Title', { content, count: data.length }),
+    },
+  };
 }
+
+export const meta: Route.MetaFunction = ({ data }) => {
+  return [
+    {
+      title: data.metaTranslations.title,
+    },
+  ];
+};
 
 export default function ContentOverviewRoute({ params }: Route.ComponentProps) {
   const content = params.content as ContentURLParams;

--- a/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx
+++ b/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx
@@ -2,6 +2,21 @@ import type { Route } from './+types/_bewerken';
 import { ContentURLParams } from '~/types/Content';
 import i18nServer from '~/modules/i18n.server';
 import { useTranslation } from 'react-i18next';
+import { data, redirect, useLoaderData } from 'react-router';
+import { getEvent, saveEvent, updateEvent } from '~/models/events.server';
+import {
+  getProject,
+  saveProject,
+  updateProject,
+} from '~/models/projects.server';
+import EventMutationForm from '~/components/EventMutationForm';
+import ProjectMutationForm from '~/components/ProjectMutationForm';
+import { EventValidator, validateEvent } from '~/validations/models/event';
+import {
+  ProjectValidator,
+  validateProject,
+} from '~/validations/models/project';
+import { ZodError } from 'zod';
 
 export const handle = {
   i18: 'EditContentRoute',
@@ -21,54 +36,66 @@ export async function loader({ params, request }: Route.LoaderArgs) {
   const t = await i18nServer.getFixedT(request, 'EditContentRoute');
   const content = params.content as ContentURLParams;
 
-  // if (content === 'posts') {
-  //   const post = await getPost(id);
-  //   return data({ post });
-  // } else {
-  //   const event = await getEvent(id);
-  //   return data({ event });
-  // }
-
-  return {
-    metaTranslations: {
-      title: t('Meta.Title', { content, count: 1 }),
-    },
+  const metaTranslations = {
+    title: t('Meta.Title', { content, count: 1 }),
   };
+
+  let payload;
+  switch (content) {
+    case 'evenementen':
+      payload = await getEvent(id);
+      break;
+
+    case 'projecten':
+      payload = await getProject(id);
+      break;
+    default:
+      throw new Error(`Content type "${content}" not found`);
+  }
+
+  return data({ payload, metaTranslations });
 }
 
 export async function action({ params, request }: Route.ActionArgs) {
-  // const content = params.content as ContentURLParams;
-  //
-  // let validatorFn;
-  //
-  // if (content === 'evenementen') {
-  //   validatorFn = validatePost;
-  // } else {
-  //   validatorFn = validateEvent;
-  // }
-  //
-  // try {
-  //   const result = await validatorFn(request);
-  //
-  //   if (content === 'evenementen') {
-  //     await savePost(result as PostValidator);
-  //   } else {
-  //     await saveEvent(result as EventValidator);
-  //   }
-  //
-  //   console.log('Data is validated and ready to be saved...');
-  //   return redirect(`/admin/${content}`);
-  // } catch (err) {
-  //   if (!(err instanceof ZodError)) {
-  //     throw err;
-  //   }
-  //
-  //   const errors = (err as ZodError).flatten().fieldErrors;
-  //   console.error('Data is invalid and cannot be saved...');
-  //   return data({ errors }, { status: 400 });
-  // }
-  console.log({ params, request: request.method });
-  return null;
+  const content = params.content as ContentURLParams;
+
+  let validatorFn;
+
+  switch (content) {
+    case 'evenementen':
+      validatorFn = validateEvent;
+      break;
+    case 'projecten':
+      validatorFn = validateProject;
+      break;
+    default:
+      throw new Error(`Content type "${content}" not found`);
+  }
+
+  try {
+    const result = await validatorFn(request);
+    const { id } = params;
+
+    switch (content) {
+      case 'evenementen':
+        await updateEvent(id, result.data as EventValidator);
+        break;
+      case 'projecten':
+        await updateProject(id, result.data as ProjectValidator);
+        break;
+    }
+
+    console.log('Data is validated and ready to be saved...');
+    return redirect(`/beheer/${content}`);
+  } catch (err) {
+    if (!(err instanceof ZodError)) {
+      throw err;
+    }
+
+    const errors = (err as ZodError).format();
+    console.error('Data is invalid and cannot be saved...');
+    return data({ errors }, { status: 400 });
+  }
 }
 
 export const meta: Route.MetaFunction = ({ data }) => {
@@ -83,11 +110,16 @@ export default function AdminEditContentRoute({
   params,
 }: Route.ComponentProps) {
   const type = params.content as ContentURLParams;
-  const { t } = useTranslation('EditContentRoute');
+  const { payload } = useLoaderData<typeof loader>();
 
-  return (
-    <div className="w-full max-w-lg">
-      <h1 className="text-4xl">{t('Title', { content: type, count: 1 })}</h1>
-    </div>
-  );
+  function getForm() {
+    switch (type) {
+      case 'projecten':
+        return <ProjectMutationForm {...payload} />;
+      case 'evenementen':
+        return <EventMutationForm {...payload} />;
+    }
+  }
+
+  return <div className="w-full">{getForm()}</div>;
 }

--- a/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx
+++ b/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx
@@ -1,14 +1,9 @@
 import type { Route } from './+types/_bewerken';
 import { ContentURLParams } from '~/types/Content';
 import i18nServer from '~/modules/i18n.server';
-import { useTranslation } from 'react-i18next';
 import { data, redirect, useLoaderData } from 'react-router';
-import { getEvent, saveEvent, updateEvent } from '~/models/events.server';
-import {
-  getProject,
-  saveProject,
-  updateProject,
-} from '~/models/projects.server';
+import { getEvent, updateEvent } from '~/models/events.server';
+import { getProject, updateProject } from '~/models/projects.server';
 import EventMutationForm from '~/components/EventMutationForm';
 import ProjectMutationForm from '~/components/ProjectMutationForm';
 import { EventValidator, validateEvent } from '~/validations/models/event';
@@ -76,17 +71,22 @@ export async function action({ params, request }: Route.ActionArgs) {
     const result = await validatorFn(request);
     const { id } = params;
 
-    switch (content) {
-      case 'evenementen':
-        await updateEvent(id, result.data as EventValidator);
-        break;
-      case 'projecten':
-        await updateProject(id, result.data as ProjectValidator);
-        break;
+    if (result.success) {
+      switch (content) {
+        case 'evenementen':
+          await updateEvent(id, result.data as EventValidator);
+          break;
+        case 'projecten':
+          await updateProject(id, result.data as ProjectValidator);
+          break;
+      }
+
+      console.log('Data is validated and ready to be saved...');
+      return redirect(`/beheer/${content}`);
     }
 
-    console.log('Data is validated and ready to be saved...');
-    return redirect(`/beheer/${content}`);
+    console.error('Data is invalid and cannot be saved...', result.error);
+    return data(result, { status: 400 });
   } catch (err) {
     if (!(err instanceof ZodError)) {
       throw err;

--- a/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx
+++ b/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx
@@ -1,15 +1,26 @@
 import type { Route } from './+types/_bewerken';
 import { ContentURLParams } from '~/types/Content';
+import i18nServer from '~/modules/i18n.server';
+import { useTranslation } from 'react-i18next';
 
-export async function loader({ params }: Route.LoaderArgs) {
-  // const { id } = params;
-  //
-  // if (!id) {
-  //   throw new Error('No ID provided');
-  // }
-  //
-  // const content = params.content as ContentURLParams;
-  //
+export const handle = {
+  i18: 'EditContentRoute',
+};
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const { id } = params;
+
+  if (!id) {
+    throw new Error('No ID provided');
+  }
+
+  if (!params.content) {
+    throw new Error('No content provided');
+  }
+
+  const t = await i18nServer.getFixedT(request, 'EditContentRoute');
+  const content = params.content as ContentURLParams;
+
   // if (content === 'posts') {
   //   const post = await getPost(id);
   //   return data({ post });
@@ -17,8 +28,12 @@ export async function loader({ params }: Route.LoaderArgs) {
   //   const event = await getEvent(id);
   //   return data({ event });
   // }
-  console.log({ params });
-  return null;
+
+  return {
+    metaTranslations: {
+      title: t('Meta.Title', { content, count: 1 }),
+    },
+  };
 }
 
 export async function action({ params, request }: Route.ActionArgs) {
@@ -56,14 +71,23 @@ export async function action({ params, request }: Route.ActionArgs) {
   return null;
 }
 
+export const meta: Route.MetaFunction = ({ data }) => {
+  return [
+    {
+      title: data.metaTranslations.title,
+    },
+  ];
+};
+
 export default function AdminEditContentRoute({
   params,
 }: Route.ComponentProps) {
   const type = params.content as ContentURLParams;
+  const { t } = useTranslation('EditContentRoute');
 
   return (
     <div className="w-full max-w-lg">
-      <h1 className="text-4xl">{`Edit ${type}`}</h1>
+      <h1 className="text-4xl">{t('Title', { content: type, count: 1 })}</h1>
     </div>
   );
 }

--- a/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
+++ b/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
@@ -1,5 +1,21 @@
 import type { Route } from './+types/_nieuw';
 import { ContentURLParams } from '~/types/Content';
+import i18nServer from '~/modules/i18n.server';
+import { useTranslation } from 'react-i18next';
+
+export const handle = {
+  i18: 'NewContentRoute',
+};
+
+export async function loader({ params, request }: Route.LoaderArgs) {
+  const t = await i18nServer.getFixedT(request, 'NewContentRoute');
+
+  return {
+    metaTranslations: {
+      title: t('Meta.Title', { content: params.content, count: 1 }),
+    },
+  };
+}
 
 export async function action({ params, request }: Route.ActionArgs) {
   // const content = params.content as ContentURLParams;
@@ -36,12 +52,21 @@ export async function action({ params, request }: Route.ActionArgs) {
   return null;
 }
 
+export const meta: Route.MetaFunction = ({ data }) => {
+  return [
+    {
+      title: data.metaTranslations.title,
+    },
+  ];
+};
+
 export default function AdminNewContentRoute({ params }: Route.ComponentProps) {
   const type = params.content as ContentURLParams;
+  const { t } = useTranslation('NewContentRoute');
 
   return (
     <div className="w-full max-w-lg">
-      <h1 className="text-4xl">{`New ${type}`}</h1>
+      <h1 className="text-4xl">{t('Title', { content: type, count: 1 })}</h1>
     </div>
   );
 }

--- a/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
+++ b/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
@@ -43,26 +43,34 @@ export async function action({ params, request }: Route.ActionArgs) {
   try {
     const result = await validatorFn(request);
 
-    switch (content) {
-      case 'projecten':
-        await saveProject(result as ProjectValidator);
-        break;
-      case 'evenementen':
-        await saveEvent(result as EventValidator);
-        break;
+    if (result.success) {
+      switch (content) {
+        case 'projecten':
+          await saveProject(result.data as ProjectValidator);
+          break;
+        case 'evenementen':
+          await saveEvent(result.data as EventValidator);
+          break;
+      }
+
+      return redirect(`/beheer/${content}`);
     }
 
-    return redirect(`/beheer/${content}`);
+    const errors = (result.error! as ZodError).flatten().fieldErrors;
+
+    return data(
+      {
+        data: result.data,
+        errors,
+      },
+      { status: 400 },
+    );
   } catch (err) {
     if (!(err instanceof ZodError)) {
-      console.error('WRONG!', { err });
       throw err;
     }
 
-    console.error({ err });
-
-    const errors = (err as ZodError).flatten().fieldErrors;
-    return data({ errors }, { status: 400 });
+    return data(err, { status: 500 });
   }
 }
 

--- a/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
+++ b/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
@@ -12,6 +12,8 @@ import { data, redirect } from 'react-router';
 import { ZodError } from 'zod';
 import ProjectMutationForm from '~/components/ProjectMutationForm';
 import EventMutationForm from '~/components/EventMutationForm';
+import { useContext } from 'react';
+import { ShoelaceContext } from '~/components/shoelace';
 
 export const handle = {
   i18: 'NewContentRoute',
@@ -94,5 +96,5 @@ export default function AdminNewContentRoute({ params }: Route.ComponentProps) {
     }
   }
 
-  return <div className="w-full max-w-lg">{getForm()}</div>;
+  return <div className="w-full">{getForm()}</div>;
 }

--- a/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
+++ b/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
@@ -12,8 +12,6 @@ import { data, redirect } from 'react-router';
 import { ZodError } from 'zod';
 import ProjectMutationForm from '~/components/ProjectMutationForm';
 import EventMutationForm from '~/components/EventMutationForm';
-import { useContext } from 'react';
-import { ShoelaceContext } from '~/components/shoelace';
 
 export const handle = {
   i18: 'NewContentRoute',
@@ -58,15 +56,7 @@ export async function action({ params, request }: Route.ActionArgs) {
       return redirect(`/beheer/${content}`);
     }
 
-    const errors = (result.error! as ZodError).flatten().fieldErrors;
-
-    return data(
-      {
-        data: result.data,
-        errors,
-      },
-      { status: 400 },
-    );
+    return data(result, { status: 400 });
   } catch (err) {
     if (!(err instanceof ZodError)) {
       throw err;

--- a/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
+++ b/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
@@ -1,7 +1,17 @@
 import type { Route } from './+types/_nieuw';
 import { ContentURLParams } from '~/types/Content';
 import i18nServer from '~/modules/i18n.server';
-import { useTranslation } from 'react-i18next';
+import {
+  ProjectValidator,
+  validateProject,
+} from '~/validations/models/project';
+import { EventValidator, validateEvent } from '~/validations/models/event';
+import { saveEvent } from '~/models/events.server';
+import { saveProject } from '~/models/projects.server';
+import { data, redirect } from 'react-router';
+import { ZodError } from 'zod';
+import ProjectMutationForm from '~/components/ProjectMutationForm';
+import EventMutationForm from '~/components/EventMutationForm';
 
 export const handle = {
   i18: 'NewContentRoute',
@@ -18,38 +28,42 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 }
 
 export async function action({ params, request }: Route.ActionArgs) {
-  // const content = params.content as ContentURLParams;
-  //
-  // let validatorFn;
-  //
-  // if (content === 'evenementen') {
-  //   validatorFn = validatePost;
-  // } else {
-  //   validatorFn = validateEvent;
-  // }
-  //
-  // try {
-  //   const result = await validatorFn(request);
-  //
-  //   if (content === 'evenementen') {
-  //     await savePost(result as PostValidator);
-  //   } else {
-  //     await saveEvent(result as EventValidator);
-  //   }
-  //
-  //   console.log('Data is validated and ready to be saved...');
-  //   return redirect(`/admin/${content}`);
-  // } catch (err) {
-  //   if (!(err instanceof ZodError)) {
-  //     throw err;
-  //   }
-  //
-  //   const errors = (err as ZodError).flatten().fieldErrors;
-  //   console.error('Data is invalid and cannot be saved...');
-  //   return data({ errors }, { status: 400 });
-  // }
-  console.log({ params, request: request.method });
-  return null;
+  const content = params.content as ContentURLParams;
+
+  let validatorFn;
+
+  switch (content) {
+    case 'projecten':
+      validatorFn = validateProject;
+      break;
+    case 'evenementen':
+      validatorFn = validateEvent;
+  }
+
+  try {
+    const result = await validatorFn(request);
+
+    switch (content) {
+      case 'projecten':
+        await saveProject(result as ProjectValidator);
+        break;
+      case 'evenementen':
+        await saveEvent(result as EventValidator);
+        break;
+    }
+
+    return redirect(`/beheer/${content}`);
+  } catch (err) {
+    if (!(err instanceof ZodError)) {
+      console.error('WRONG!', { err });
+      throw err;
+    }
+
+    console.error({ err });
+
+    const errors = (err as ZodError).flatten().fieldErrors;
+    return data({ errors }, { status: 400 });
+  }
 }
 
 export const meta: Route.MetaFunction = ({ data }) => {
@@ -62,11 +76,15 @@ export const meta: Route.MetaFunction = ({ data }) => {
 
 export default function AdminNewContentRoute({ params }: Route.ComponentProps) {
   const type = params.content as ContentURLParams;
-  const { t } = useTranslation('NewContentRoute');
 
-  return (
-    <div className="w-full max-w-lg">
-      <h1 className="text-4xl">{t('Title', { content: type, count: 1 })}</h1>
-    </div>
-  );
+  function getForm() {
+    switch (type) {
+      case 'projecten':
+        return <ProjectMutationForm />;
+      case 'evenementen':
+        return <EventMutationForm />;
+    }
+  }
+
+  return <div className="w-full max-w-lg">{getForm()}</div>;
 }

--- a/app/routes/($lang)/inloggen/LoginFormComponent.tsx
+++ b/app/routes/($lang)/inloggen/LoginFormComponent.tsx
@@ -51,9 +51,9 @@ export default function LoginFormComponent({ action, errors, values }: Props) {
         type="email"
         label={t('Email')}
         value={values?.emailaddress ?? ''}
-        error={errors?.emailaddress
-          ?.map((error) => t(`Errors.emailaddress.${error.errorCode}`))
-          .join(', ')}
+        error={errors?.emailaddress?.map((error) =>
+          t(`Errors.emailaddress.${error.errorCode}`),
+        )}
       />
 
       <Input
@@ -63,9 +63,9 @@ export default function LoginFormComponent({ action, errors, values }: Props) {
         label={t('Password')}
         passwordToggle
         value={values?.password ?? ''}
-        error={errors?.password
-          ?.map((error) => t(`Errors.password.${error.errorCode}`))
-          .join(', ')}
+        error={errors?.password?.map((error) =>
+          t(`Errors.password.${error.errorCode}`),
+        )}
       />
 
       <SlAlert variant="danger" open={!!errors?.userNotFound}>

--- a/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.tsx
+++ b/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.tsx
@@ -36,9 +36,9 @@ export default function ForgetPasswordFormComponent({ action, errors }: Props) {
           type="email"
           label={t('EmailInputLabel')}
           autocomplete="email"
-          error={errors?.emailaddress
-            ?.map((error) => t(`Errors.emailaddress.${error.errorCode}`))
-            .join(', ')}
+          error={errors?.emailaddress?.map((error) =>
+            t(`Errors.emailaddress.${error.errorCode}`),
+          )}
         />
 
         <SlButton className="self-end" variant="primary" type="submit">

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -128,4 +128,9 @@
   .Puck > div:not(#puck-portal-root) {
     height: 100%;
   }
+
+  .inline-locale-selector::part(label) {
+    padding-inline-start: var(--sl-spacing-2x-small);
+    padding-inline-end: var(--sl-spacing-2x-small);
+  }
 }

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -128,5 +128,4 @@
   .Puck > div:not(#puck-portal-root) {
     height: 100%;
   }
-
 }

--- a/app/types/Content.ts
+++ b/app/types/Content.ts
@@ -1,1 +1,17 @@
+import { supportedLanguages, SupportedLanguages } from '~/config/i18n';
+
 export type ContentURLParams = 'evenementen' | 'projecten';
+
+export type LocalisedValue = Record<SupportedLanguages, string>;
+
+export function isLocalisedValue(value: unknown): value is LocalisedValue {
+  if (typeof value !== 'object' || value === null) return false;
+
+  // Get the keys from the value object
+  const keys = Object.keys(value);
+
+  // Check if all keys are valid supported languages
+  return keys.every((key) =>
+    supportedLanguages.includes(key as SupportedLanguages),
+  );
+}

--- a/app/types/DeepPartial.ts
+++ b/app/types/DeepPartial.ts
@@ -1,0 +1,3 @@
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};

--- a/app/types/Input.ts
+++ b/app/types/Input.ts
@@ -1,0 +1,20 @@
+import {
+  SlBlurEvent,
+  SlChangeEvent,
+  SlClearEvent,
+  SlFocusEvent,
+  SlInputEvent,
+  SlInvalidEvent,
+} from '@shoelace-style/shoelace';
+
+/**
+ * Define custom event handler types
+ */
+export type SlInputEventHandlers = {
+  onSlBlur?: (e: SlBlurEvent) => void;
+  onSlChange?: (e: SlChangeEvent) => void;
+  onSlClear?: (e: SlClearEvent) => void;
+  onSlFocus?: (e: SlFocusEvent) => void;
+  onSlInput?: (e: SlInputEvent) => void;
+  onSlInvalid?: (e: SlInvalidEvent) => void;
+};

--- a/app/types/Validations.ts
+++ b/app/types/Validations.ts
@@ -1,0 +1,14 @@
+import { SafeParseError, SafeParseSuccess } from 'zod';
+
+export type ErrorData<Data> = {
+  [Prop in keyof Data]: string;
+};
+
+export type SuccessValidation<Data> = SafeParseSuccess<Data>;
+export type ErrorValidation<Data> = SafeParseError<Data> & {
+  data: ErrorData<Data>;
+};
+export type ErrorResponse<Error, Data> = {
+  errors: Error;
+  data: ErrorData<Data>;
+};

--- a/app/types/Validations.ts
+++ b/app/types/Validations.ts
@@ -1,14 +1,15 @@
 import { SafeParseError, SafeParseSuccess } from 'zod';
+import { LocalisedValue } from '~/types/Content';
 
-export type ErrorData<Data> = {
-  [Prop in keyof Data]: string;
+export type Data<Payload> = {
+  [Prop in keyof Payload]: string | LocalisedValue;
 };
 
-export type SuccessValidation<Data> = SafeParseSuccess<Data>;
-export type ErrorValidation<Data> = SafeParseError<Data> & {
-  data: ErrorData<Data>;
+export type SuccessValidation<Payload> = SafeParseSuccess<Payload>;
+export type ErrorValidation<Payload> = SafeParseError<Payload> & {
+  data: Data<Payload>;
 };
-export type ErrorResponse<Error, Data> = {
+export type ErrorResponse<Error, Payload> = {
   errors: Error;
-  data: ErrorData<Data>;
+  data: Data<Payload>;
 };

--- a/app/types/Validations.ts
+++ b/app/types/Validations.ts
@@ -2,7 +2,8 @@ import { SafeParseError, SafeParseSuccess } from 'zod';
 import { LocalisedValue } from '~/types/Content';
 
 export type Data<Payload> = {
-  [Prop in keyof Payload]: string | LocalisedValue;
+  [Prop in keyof Payload]: Payload[Prop] extends LocalisedValue ? LocalisedValue
+  : Payload[Prop];
 };
 
 export type SuccessValidation<Payload> = SafeParseSuccess<Payload>;

--- a/app/utils/content.test.ts
+++ b/app/utils/content.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+import { countErrorsForLocalisedFields, transformFormData } from './content';
+
+describe('Content utilities', () => {
+  test('Parse a localised form data object into a localised value object', () => {
+    const formData = new FormData();
+    formData.append('title.en', 'Hello');
+    formData.append('title.nl', 'Hallo');
+    formData.append('title.pap', 'Bon dia');
+    formData.append('description.en', 'World');
+    formData.append('description.nl', 'Wereld');
+    formData.append('description.pap', 'Mundu');
+
+    const result = transformFormData(formData);
+
+    expect(result).toEqual({
+      title: {
+        en: 'Hello',
+        nl: 'Hallo',
+        pap: 'Bon dia',
+      },
+      description: {
+        en: 'World',
+        nl: 'Wereld',
+        pap: 'Mundu',
+      },
+    });
+  });
+
+  test('Retrieve the number of errors for each localised field', () => {
+    const errors = {
+      _errors: [],
+      title: {
+        _errors: [],
+        nl: {
+          _errors: ['This field is required'],
+        },
+      },
+      description: {
+        _errors: [],
+        en: {
+          _errors: ['This field is required'],
+        },
+      },
+    };
+
+    const result = countErrorsForLocalisedFields(errors);
+
+    expect(result).toEqual({
+      nl: 1,
+      en: 1,
+    });
+  });
+});

--- a/app/utils/content.ts
+++ b/app/utils/content.ts
@@ -1,10 +1,5 @@
 // Define interfaces for the original and transformed data structures
-import {
-  inferFormattedError,
-  ZodError,
-  ZodFormattedError,
-  ZodTypeAny,
-} from 'zod';
+import { inferFormattedError, ZodTypeAny } from 'zod';
 
 interface RawFormData {
   [key: string]: string | File;

--- a/app/utils/content.ts
+++ b/app/utils/content.ts
@@ -56,6 +56,7 @@ export function countErrorsForLocalisedFields<D extends ZodTypeAny>(
   for (const field in errors) {
     if (field === '_errors') continue;
 
+    // @ts-expect-error - We know that fieldErrors is an object
     const fieldErrors = errors[field];
     if (!fieldErrors || typeof fieldErrors !== 'object') continue;
 

--- a/app/utils/content.ts
+++ b/app/utils/content.ts
@@ -1,0 +1,79 @@
+// Define interfaces for the original and transformed data structures
+import {
+  inferFormattedError,
+  ZodError,
+  ZodFormattedError,
+  ZodTypeAny,
+} from 'zod';
+
+interface RawFormData {
+  [key: string]: string | File;
+}
+
+interface LocalizedField {
+  [locale: string]: string;
+}
+
+interface TransformedFormData {
+  [key: string]: string | LocalizedField; // For any additional fields
+}
+
+/**
+ * Transforms a form data object with nested keys into a properly structured object
+ * @param formData
+ */
+export function transformFormData(formData: FormData): TransformedFormData {
+  const result: Partial<TransformedFormData> = {};
+  const data: RawFormData = Object.fromEntries(formData);
+
+  Object.keys(data).forEach((key) => {
+    if (key.includes('.')) {
+      const [fieldName, locale] = key.split('.');
+
+      // Initialize the object for this field if it doesn't exist yet
+      if (!result[fieldName]) {
+        result[fieldName] = {} as LocalizedField;
+      }
+
+      // Check if the field is not a file
+      if (data[key] instanceof File) {
+        return;
+      }
+
+      // Add the localized value
+      (result[fieldName] as LocalizedField)[locale] = data[key];
+    } else if (!(data[key] instanceof File)) {
+      // For regular fields (not files), just copy them directly
+      result[key] = data[key];
+    }
+  });
+
+  return result as TransformedFormData;
+}
+
+export function countErrorsForLocalisedFields<D extends ZodTypeAny>(
+  errors: inferFormattedError<D>,
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  const locales = ['en', 'nl', 'pap']; // Define known locales
+
+  // Iterate over the error fields
+  for (const field in errors) {
+    if (field === '_errors') continue;
+
+    const fieldErrors = errors[field];
+    if (!fieldErrors || typeof fieldErrors !== 'object') continue;
+
+    // Check for localized errors within each field
+    for (const locale of locales) {
+      if (fieldErrors[locale]?._errors?.length) {
+        if (!result[locale]) {
+          result[locale] = 0;
+        }
+        result[locale] += fieldErrors[locale]._errors.length;
+      }
+    }
+  }
+
+  return result;
+}

--- a/app/validations/models/event.ts
+++ b/app/validations/models/event.ts
@@ -27,15 +27,10 @@ export async function validateEvent(
   const clonedRequest = request.clone();
   const formData = await clonedRequest.formData();
   const transformedData = transformFormData(formData);
-  console.log({
-    formData: Object.fromEntries(formData),
-    transformedData,
-  });
   transformedData.eventDate = `${transformedData.eventDate}:00.000Z`;
 
   const result = eventValidator.safeParse(transformedData);
 
-  console.log(result);
   if (result.success) {
     return result as SuccessValidation<EventValidator>;
   }

--- a/app/validations/models/event.ts
+++ b/app/validations/models/event.ts
@@ -27,6 +27,10 @@ export async function validateEvent(
   const clonedRequest = request.clone();
   const formData = await clonedRequest.formData();
   const transformedData = transformFormData(formData);
+  console.log({
+    formData: Object.fromEntries(formData),
+    transformedData,
+  });
   transformedData.eventDate = `${transformedData.eventDate}:00.000Z`;
 
   const result = eventValidator.safeParse(transformedData);
@@ -37,7 +41,7 @@ export async function validateEvent(
   }
 
   return {
-    ...result,
+    success: false,
     errors: result.error.format(),
     data: transformedData as Data<EventValidator>,
   } as ErrorValidation<EventValidator>;

--- a/app/validations/models/event.ts
+++ b/app/validations/models/event.ts
@@ -15,7 +15,8 @@ export type EventErrors = z.inferFlattenedErrors<
 
 export async function validateEvent(request: Request): Promise<EventValidator> {
   const clonedRequest = request.clone();
-  const formData = await clonedRequest.formData();
+  const formData = Object.fromEntries(await clonedRequest.formData());
+  formData.eventDate = `${formData.eventDate}:00.000Z`;
 
   return eventValidator.parse(formData);
 }

--- a/app/validations/models/event.ts
+++ b/app/validations/models/event.ts
@@ -1,22 +1,23 @@
 import { z } from 'zod';
-import {
-  SuccessValidation,
-  ErrorValidation,
-  ErrorData,
-} from '~/types/Validations';
+import { SuccessValidation, ErrorValidation, Data } from '~/types/Validations';
+import { transformFormData } from '~/utils/content';
+
+const localisedStringValidations = z.object({
+  nl: z.string().min(1),
+  en: z.string().min(1),
+  pap: z.string().min(1),
+});
 
 export const eventValidator = z.object({
-  title: z.string().min(1),
-  description: z.string().min(1),
+  title: localisedStringValidations,
+  description: localisedStringValidations,
   eventDate: z.string().datetime(),
   address: z.string().min(1),
   link: z.string().min(1),
 });
 
 export type EventValidator = z.infer<typeof eventValidator>;
-export type EventErrors = z.inferFlattenedErrors<
-  typeof eventValidator
->['fieldErrors'];
+export type EventErrors = z.inferFormattedError<typeof eventValidator>;
 
 export async function validateEvent(
   request: Request,
@@ -24,17 +25,20 @@ export async function validateEvent(
   SuccessValidation<EventValidator> | ErrorValidation<EventValidator>
 > {
   const clonedRequest = request.clone();
-  const formData = Object.fromEntries(await clonedRequest.formData());
-  formData.eventDate = `${formData.eventDate}:00.000Z`;
+  const formData = await clonedRequest.formData();
+  const transformedData = transformFormData(formData);
+  transformedData.eventDate = `${transformedData.eventDate}:00.000Z`;
 
-  const result = eventValidator.safeParse(formData);
+  const result = eventValidator.safeParse(transformedData);
 
+  console.log(result);
   if (result.success) {
     return result as SuccessValidation<EventValidator>;
   }
 
   return {
     ...result,
-    data: formData as ErrorData<EventValidator>,
+    errors: result.error.format(),
+    data: transformedData as Data<EventValidator>,
   } as ErrorValidation<EventValidator>;
 }

--- a/app/validations/models/event.ts
+++ b/app/validations/models/event.ts
@@ -27,7 +27,6 @@ export async function validateEvent(
   const clonedRequest = request.clone();
   const formData = await clonedRequest.formData();
   const transformedData = transformFormData(formData);
-  transformedData.eventDate = `${transformedData.eventDate}:00.000Z`;
 
   const result = eventValidator.safeParse(transformedData);
 

--- a/app/validations/models/event.ts
+++ b/app/validations/models/event.ts
@@ -1,4 +1,9 @@
 import { z } from 'zod';
+import {
+  SuccessValidation,
+  ErrorValidation,
+  ErrorData,
+} from '~/types/Validations';
 
 export const eventValidator = z.object({
   title: z.string().min(1),
@@ -13,10 +18,23 @@ export type EventErrors = z.inferFlattenedErrors<
   typeof eventValidator
 >['fieldErrors'];
 
-export async function validateEvent(request: Request): Promise<EventValidator> {
+export async function validateEvent(
+  request: Request,
+): Promise<
+  SuccessValidation<EventValidator> | ErrorValidation<EventValidator>
+> {
   const clonedRequest = request.clone();
   const formData = Object.fromEntries(await clonedRequest.formData());
   formData.eventDate = `${formData.eventDate}:00.000Z`;
 
-  return eventValidator.parse(formData);
+  const result = eventValidator.safeParse(formData);
+
+  if (result.success) {
+    return result as SuccessValidation<EventValidator>;
+  }
+
+  return {
+    ...result,
+    data: formData as ErrorData<EventValidator>,
+  } as ErrorValidation<EventValidator>;
 }

--- a/app/validations/models/event.ts
+++ b/app/validations/models/event.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const eventValidator = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1),
+  eventDate: z.string().datetime(),
+  address: z.string().min(1),
+  link: z.string().min(1),
+});
+
+export type EventValidator = z.infer<typeof eventValidator>;
+export type EventErrors = z.inferFlattenedErrors<
+  typeof eventValidator
+>['fieldErrors'];
+
+export async function validateEvent(request: Request): Promise<EventValidator> {
+  const clonedRequest = request.clone();
+  const formData = await clonedRequest.formData();
+
+  return eventValidator.parse(formData);
+}

--- a/app/validations/models/project.ts
+++ b/app/validations/models/project.ts
@@ -1,4 +1,9 @@
 import { z } from 'zod';
+import {
+  ErrorData,
+  ErrorValidation,
+  SuccessValidation,
+} from '~/types/Validations';
 
 export const projectValidator = z.object({
   title: z.string().min(1),
@@ -14,9 +19,20 @@ export type ProjectErrors = z.inferFlattenedErrors<
 
 export async function validateProject(
   request: Request,
-): Promise<ProjectValidator> {
+): Promise<
+  SuccessValidation<ProjectValidator> | ErrorValidation<ProjectValidator>
+> {
   const clonedRequest = request.clone();
   const formData = Object.fromEntries(await clonedRequest.formData());
 
-  return projectValidator.parse(formData);
+  const result = projectValidator.safeParse(formData);
+
+  if (result.success) {
+    return result as SuccessValidation<ProjectValidator>;
+  }
+
+  return {
+    ...result,
+    data: formData as ErrorData<ProjectValidator>,
+  } as ErrorValidation<ProjectValidator>;
 }

--- a/app/validations/models/project.ts
+++ b/app/validations/models/project.ts
@@ -1,9 +1,5 @@
 import { z } from 'zod';
-import {
-  ErrorData,
-  ErrorValidation,
-  SuccessValidation,
-} from '~/types/Validations';
+import { Data, ErrorValidation, SuccessValidation } from '~/types/Validations';
 
 export const projectValidator = z.object({
   title: z.string().min(1),
@@ -33,6 +29,6 @@ export async function validateProject(
 
   return {
     ...result,
-    data: formData as ErrorData<ProjectValidator>,
+    data: formData as Data<ProjectValidator>,
   } as ErrorValidation<ProjectValidator>;
 }

--- a/app/validations/models/project.ts
+++ b/app/validations/models/project.ts
@@ -1,17 +1,22 @@
 import { z } from 'zod';
 import { Data, ErrorValidation, SuccessValidation } from '~/types/Validations';
+import { transformFormData } from '~/utils/content';
+
+const localisedStringValidations = z.object({
+  nl: z.string().min(1),
+  en: z.string().min(1),
+  pap: z.string().min(1),
+});
 
 export const projectValidator = z.object({
-  title: z.string().min(1),
-  description: z.string().min(1),
-  summary: z.string().min(1),
+  title: localisedStringValidations,
+  description: localisedStringValidations,
+  summary: localisedStringValidations,
   slug: z.string().min(1),
 });
 
 export type ProjectValidator = z.infer<typeof projectValidator>;
-export type ProjectErrors = z.inferFlattenedErrors<
-  typeof projectValidator
->['fieldErrors'];
+export type ProjectErrors = z.inferFormattedError<typeof projectValidator>;
 
 export async function validateProject(
   request: Request,
@@ -19,16 +24,18 @@ export async function validateProject(
   SuccessValidation<ProjectValidator> | ErrorValidation<ProjectValidator>
 > {
   const clonedRequest = request.clone();
-  const formData = Object.fromEntries(await clonedRequest.formData());
+  const formData = await clonedRequest.formData();
+  const transformedData = transformFormData(formData);
 
-  const result = projectValidator.safeParse(formData);
+  const result = projectValidator.safeParse(transformedData);
 
   if (result.success) {
     return result as SuccessValidation<ProjectValidator>;
   }
 
   return {
-    ...result,
-    data: formData as Data<ProjectValidator>,
+    success: false,
+    errors: result.error.format(),
+    data: transformedData as Data<ProjectValidator>,
   } as ErrorValidation<ProjectValidator>;
 }

--- a/app/validations/models/project.ts
+++ b/app/validations/models/project.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const projectValidator = z.object({
+  title: z.string().min(1),
+  description: z.string().min(1),
+  summary: z.string().min(1),
+  slug: z.string().min(1),
+});
+
+export type ProjectValidator = z.infer<typeof projectValidator>;
+export type ProjectErrors = z.inferFlattenedErrors<
+  typeof projectValidator
+>['fieldErrors'];
+
+export async function validateProject(
+  request: Request,
+): Promise<ProjectValidator> {
+  const clonedRequest = request.clone();
+  const formData = Object.fromEntries(await clonedRequest.formData());
+
+  return projectValidator.parse(formData);
+}


### PR DESCRIPTION
- **Added localised meta data for the content routes**
- **A lot of small changes to the translations, and added a "new" button to te crud overview route.**
- **Created event form**
- **Created project form, and made some smaller improvements to the event form**
- **Mutation forms are now processed and saved for 'Create'**
- **The create flow is basically done, including validation before saving**
- **Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component.**
- **Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting.**
- **Add LocalisedInput component and enhance LocaleSelector with new props and event handling**
- **Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling**
- **Fixed a lot of lint and typecheck errors**
- **Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF**
- **GH Actions now performs a build on normal push**
- **Enabled the UPDATE flow end to end.**
- **UPDATE route now properly returns validation errors, otherwise it saves to DB**
