### PR TITLE
feature/WAT 84 Hook pages into crud flow

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,43 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Created &quot;new&quot; flow for generic pages.">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="PageMutationForm now also shows errors, and made slug unique in prisma">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.storybook/preview.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/.storybook/preview.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Anchor.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Anchor.stories.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ArticleCard.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ArticleCard.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ArtistProfileSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ArtistProfileSummary.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ArtistsSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ArtistsSummary.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Breadcrumbs.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Breadcrumbs.stories.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ChangePasswordForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ChangePasswordForm.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ContentTable.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ContentTable.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/DateInput.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/DateInput.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/EventSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventSummary.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Header.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Header.stories.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Heading.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Heading.stories.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Input.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/LocalisedInput.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocalisedInput.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Logo.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Logo.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageEditor.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageMutationForm.stories.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/PageMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/prisma/schema.prisma" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/schema.prisma" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageRenderer.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageRenderer.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProductSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProductSummary.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/ProjectSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectSummary.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/RichTextEditor.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/RichTextEditor.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/SubMenu.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/SubMenu.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/Tags.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Tags.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/YearSelector.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/YearSelector.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/ConfirmDeleteDialog.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/ConfirmDeleteDialog.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/DeletionNotification.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/DeletionNotification.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/AdminMenu.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/AdminMenu.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/inloggen/LoginFormComponent.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/inloggen/LoginFormComponent.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordConfirmation.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordConfirmation.stories.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.stories.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -382,15 +415,8 @@
       <workItem from="1744182959032" duration="3484000" />
       <workItem from="1744186455792" duration="6845000" />
       <workItem from="1744269733595" duration="10876000" />
-      <workItem from="1744286517948" duration="10065000" />
-    </task>
-    <task id="LOCAL-00076" summary="Setup basic account page structure so that we can start with the admin work">
-      <option name="closed" value="true" />
-      <created>1741781802954</created>
-      <option name="number" value="00076" />
-      <option name="presentableId" value="LOCAL-00076" />
-      <option name="project" value="LOCAL" />
-      <updated>1741781802954</updated>
+      <workItem from="1744286517948" duration="11011000" />
+      <workItem from="1744356213721" duration="2406000" />
     </task>
     <task id="LOCAL-00077" summary="Cleaned up the content structures, removing stuff we don't need. Also added link to projects for an admin">
       <option name="closed" value="true" />
@@ -776,7 +802,15 @@
       <option name="project" value="LOCAL" />
       <updated>1744293439309</updated>
     </task>
-    <option name="localTasksCounter" value="125" />
+    <task id="LOCAL-00125" summary="PageMutationForm now also shows errors, and made slug unique in prisma">
+      <option name="closed" value="true" />
+      <created>1744296682184</created>
+      <option name="number" value="00125" />
+      <option name="presentableId" value="LOCAL-00125" />
+      <option name="project" value="LOCAL" />
+      <updated>1744296682184</updated>
+    </task>
+    <option name="localTasksCounter" value="126" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -819,7 +853,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
     <MESSAGE value="Fixed a lot of lint and typecheck errors" />
     <MESSAGE value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
     <MESSAGE value="GH Actions now performs a build on normal push" />
@@ -844,7 +877,8 @@
     <MESSAGE value="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally." />
     <MESSAGE value="Reworked the Puck editor to support for page/SEO metadata." />
     <MESSAGE value="Created &quot;new&quot; flow for generic pages." />
-    <option name="LAST_COMMIT_MESSAGE" value="Created &quot;new&quot; flow for generic pages." />
+    <MESSAGE value="PageMutationForm now also shows errors, and made slug unique in prisma" />
+    <option name="LAST_COMMIT_MESSAGE" value="PageMutationForm now also shows errors, and made slug unique in prisma" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,11 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="The slug can now also be set in Puck">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Ran prisma migrate to updated db to new schema">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/scripts/diff-db-staging.zsh" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/diff-db-staging.zsh" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/models/pages.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/pages.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/prisma/seed/_pageContent.ts" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/seed/_pageContent.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -156,7 +157,7 @@
     "npm.docker:start.executor": "Run",
     "prettierjs.PrettierConfiguration.Package": "/Users/lody/dev/projects/watershed-website/node_modules/prettier",
     "settings.editor.selected.configurable": "settings.typescriptcompiler",
-    "ts.external.directory.path": "/Applications/PhpStorm.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external",
+    "ts.external.directory.path": "/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib",
     "vue.rearranger.settings.migration": "true"
   },
   "keyToStringList": {
@@ -383,23 +384,7 @@
       <workItem from="1744186455792" duration="6845000" />
       <workItem from="1744269733595" duration="10876000" />
       <workItem from="1744286517948" duration="11011000" />
-      <workItem from="1744356213721" duration="5331000" />
-    </task>
-    <task id="LOCAL-00079" summary="Created the dynamic content route, and added a basic implementation of the content table.">
-      <option name="closed" value="true" />
-      <created>1741785775699</created>
-      <option name="number" value="00079" />
-      <option name="presentableId" value="LOCAL-00079" />
-      <option name="project" value="LOCAL" />
-      <updated>1741785775699</updated>
-    </task>
-    <task id="LOCAL-00080" summary="Made a basic implementation of a dynamic event/project overview">
-      <option name="closed" value="true" />
-      <created>1741789215526</created>
-      <option name="number" value="00080" />
-      <option name="presentableId" value="LOCAL-00080" />
-      <option name="project" value="LOCAL" />
-      <updated>1741789215526</updated>
+      <workItem from="1744356213721" duration="6305000" />
     </task>
     <task id="LOCAL-00081" summary="Content table is now localised and has a more robust value parser.">
       <option name="closed" value="true" />
@@ -777,7 +762,23 @@
       <option name="project" value="LOCAL" />
       <updated>1744362418411</updated>
     </task>
-    <option name="localTasksCounter" value="128" />
+    <task id="LOCAL-00128" summary="DB diff script is runnable from npm and fixed the wrong port check method.">
+      <option name="closed" value="true" />
+      <created>1744362859461</created>
+      <option name="number" value="00128" />
+      <option name="presentableId" value="LOCAL-00128" />
+      <option name="project" value="LOCAL" />
+      <updated>1744362859461</updated>
+    </task>
+    <task id="LOCAL-00129" summary="Ran prisma migrate to updated db to new schema">
+      <option name="closed" value="true" />
+      <created>1744363054265</created>
+      <option name="number" value="00129" />
+      <option name="presentableId" value="LOCAL-00129" />
+      <option name="project" value="LOCAL" />
+      <updated>1744363054265</updated>
+    </task>
+    <option name="localTasksCounter" value="130" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -820,8 +821,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="GH Actions now performs a build on normal push" />
-    <MESSAGE value="Enabled the UPDATE flow end to end." />
     <MESSAGE value="Renamed news link to events" />
     <MESSAGE value="Moved the components from the news route to the generic components folder as they can be reused." />
     <MESSAGE value="Removed the news routes" />
@@ -845,7 +844,9 @@
     <MESSAGE value="PageMutationForm now also shows errors, and made slug unique in prisma" />
     <MESSAGE value="Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged." />
     <MESSAGE value="The slug can now also be set in Puck" />
-    <option name="LAST_COMMIT_MESSAGE" value="The slug can now also be set in Puck" />
+    <MESSAGE value="DB diff script is runnable from npm and fixed the wrong port check method." />
+    <MESSAGE value="Ran prisma migrate to updated db to new schema" />
+    <option name="LAST_COMMIT_MESSAGE" value="Ran prisma migrate to updated db to new schema" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,11 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Ran prisma migrate to updated db to new schema">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Pages can now be edited and saved  Also added slugs to seeding scripts">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/models/pages.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/pages.server.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/prisma/seed/_pageContent.ts" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/seed/_pageContent.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.translations.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -384,15 +382,7 @@
       <workItem from="1744186455792" duration="6845000" />
       <workItem from="1744269733595" duration="10876000" />
       <workItem from="1744286517948" duration="11011000" />
-      <workItem from="1744356213721" duration="6305000" />
-    </task>
-    <task id="LOCAL-00081" summary="Content table is now localised and has a more robust value parser.">
-      <option name="closed" value="true" />
-      <created>1741790225520</created>
-      <option name="number" value="00081" />
-      <option name="presentableId" value="LOCAL-00081" />
-      <option name="project" value="LOCAL" />
-      <updated>1741790225520</updated>
+      <workItem from="1744356213721" duration="7443000" />
     </task>
     <task id="LOCAL-00082" summary="Created all needed routes for CRUD functionality.">
       <option name="closed" value="true" />
@@ -778,7 +768,15 @@
       <option name="project" value="LOCAL" />
       <updated>1744363054265</updated>
     </task>
-    <option name="localTasksCounter" value="130" />
+    <task id="LOCAL-00130" summary="Pages can now be edited and saved  Also added slugs to seeding scripts">
+      <option name="closed" value="true" />
+      <created>1744364119344</created>
+      <option name="number" value="00130" />
+      <option name="presentableId" value="LOCAL-00130" />
+      <option name="project" value="LOCAL" />
+      <updated>1744364119344</updated>
+    </task>
+    <option name="localTasksCounter" value="131" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -821,7 +819,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Renamed news link to events" />
     <MESSAGE value="Moved the components from the news route to the generic components folder as they can be reused." />
     <MESSAGE value="Removed the news routes" />
     <MESSAGE value="Added fonts and setup styles for the heading" />
@@ -846,7 +843,8 @@
     <MESSAGE value="The slug can now also be set in Puck" />
     <MESSAGE value="DB diff script is runnable from npm and fixed the wrong port check method." />
     <MESSAGE value="Ran prisma migrate to updated db to new schema" />
-    <option name="LAST_COMMIT_MESSAGE" value="Ran prisma migrate to updated db to new schema" />
+    <MESSAGE value="Pages can now be edited and saved  Also added slugs to seeding scripts" />
+    <option name="LAST_COMMIT_MESSAGE" value="Pages can now be edited and saved  Also added slugs to seeding scripts" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,43 +4,11 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="PageMutationForm now also shows errors, and made slug unique in prisma">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/.storybook/preview.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/.storybook/preview.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Anchor.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Anchor.stories.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ArticleCard.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ArticleCard.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ArtistProfileSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ArtistProfileSummary.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ArtistsSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ArtistsSummary.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Breadcrumbs.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Breadcrumbs.stories.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ChangePasswordForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ChangePasswordForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ContentTable.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ContentTable.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/DateInput.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/DateInput.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventMutationForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/EventSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/EventSummary.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Header.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Header.stories.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Heading.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Heading.stories.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Input.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Input.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocaleSelector.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/LocalisedInput.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/LocalisedInput.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Logo.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Logo.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/PageEditor.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/PageMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageMutationForm.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageEditor.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/PageMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/PageRenderer.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageRenderer.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ProductSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProductSummary.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ProjectMutationForm.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectMutationForm.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ProjectSummary.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ProjectSummary.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/RichTextEditor.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/RichTextEditor.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/SubMenu.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/SubMenu.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/Tags.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/Tags.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/YearSelector.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/YearSelector.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/ConfirmDeleteDialog.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/ConfirmDeleteDialog.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/DeletionNotification.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/DeletionNotification.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/AdminMenu.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/AdminMenu.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/inloggen/LoginFormComponent.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/inloggen/LoginFormComponent.stories.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordConfirmation.stories.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordConfirmation.stories.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/config/puck.config.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/puck.config.tsx" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -416,15 +384,7 @@
       <workItem from="1744186455792" duration="6845000" />
       <workItem from="1744269733595" duration="10876000" />
       <workItem from="1744286517948" duration="11011000" />
-      <workItem from="1744356213721" duration="2406000" />
-    </task>
-    <task id="LOCAL-00077" summary="Cleaned up the content structures, removing stuff we don't need. Also added link to projects for an admin">
-      <option name="closed" value="true" />
-      <created>1741782251665</created>
-      <option name="number" value="00077" />
-      <option name="presentableId" value="LOCAL-00077" />
-      <option name="project" value="LOCAL" />
-      <updated>1741782251665</updated>
+      <workItem from="1744356213721" duration="4577000" />
     </task>
     <task id="LOCAL-00078" summary="Refactored the account menu into a separate component and added admin/ route">
       <option name="closed" value="true" />
@@ -810,7 +770,15 @@
       <option name="project" value="LOCAL" />
       <updated>1744296682184</updated>
     </task>
-    <option name="localTasksCounter" value="126" />
+    <task id="LOCAL-00126" summary="Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged.">
+      <option name="closed" value="true" />
+      <created>1744358709945</created>
+      <option name="number" value="00126" />
+      <option name="presentableId" value="LOCAL-00126" />
+      <option name="project" value="LOCAL" />
+      <updated>1744358709945</updated>
+    </task>
+    <option name="localTasksCounter" value="127" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -853,7 +821,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Fixed a lot of lint and typecheck errors" />
     <MESSAGE value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
     <MESSAGE value="GH Actions now performs a build on normal push" />
     <MESSAGE value="Enabled the UPDATE flow end to end." />
@@ -878,7 +845,8 @@
     <MESSAGE value="Reworked the Puck editor to support for page/SEO metadata." />
     <MESSAGE value="Created &quot;new&quot; flow for generic pages." />
     <MESSAGE value="PageMutationForm now also shows errors, and made slug unique in prisma" />
-    <option name="LAST_COMMIT_MESSAGE" value="PageMutationForm now also shows errors, and made slug unique in prisma" />
+    <MESSAGE value="Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged." />
+    <option name="LAST_COMMIT_MESSAGE" value="Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,11 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged.">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="The slug can now also be set in Puck">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/PageEditor.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/PageMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageMutationForm.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/config/puck.config.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/puck.config.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/scripts/diff-db-staging.zsh" beforeDir="false" afterPath="$PROJECT_DIR$/scripts/diff-db-staging.zsh" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -117,61 +116,61 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Attach to Node.js/Chrome.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
-    &quot;JavaScript Debug.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
-    &quot;RunOnceActivity.OpenDatabaseViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
-    &quot;Vitest.All Tests.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.Content utilities.Parse a localised form data object into a localised value object.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.Content utilities.Retrieve the number of errors for each localised field.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.Content utilities.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.Validating the page.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.parseURL.Return the correct url for \&quot;/over-ons/team\&quot;.executor&quot;: &quot;Debug&quot;,
-    &quot;Vitest.parseURL.Return the correct urls for \&quot;/contact\&quot;.executor&quot;: &quot;Debug&quot;,
-    &quot;Vitest.validateLogin.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.validateLogin.should return success: false when emailaddress is invalid.executor&quot;: &quot;Run&quot;,
-    &quot;Vitest.validateLogin.should return success: false when emailaddress is missing.executor&quot;: &quot;Run&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;feature/WAT-84__Hook__pages__into__crud__flow&quot;,
-    &quot;javascript.nodejs.core.library.configured.version&quot;: &quot;22.11.0&quot;,
-    &quot;javascript.nodejs.core.library.typings.version&quot;: &quot;22.9.0&quot;,
-    &quot;last_opened_file_path&quot;: &quot;/Users/lody/dev/projects/watershed-website/app/routes/_index&quot;,
-    &quot;node.js.detected.package.standard&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.standard&quot;: &quot;&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_interpreter_path&quot;: &quot;node&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;npm.Dev.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.Develop.executor&quot;: &quot;Run&quot;,
-    &quot;npm.Storybook.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.db:generate.executor&quot;: &quot;Run&quot;,
-    &quot;npm.db:push:seed.executor&quot;: &quot;Run&quot;,
-    &quot;npm.dev:app.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.dev:remix.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.dev:storybook.executor&quot;: &quot;Debug&quot;,
-    &quot;npm.docker:start.executor&quot;: &quot;Run&quot;,
-    &quot;prettierjs.PrettierConfiguration.Package&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/prettier&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;settings.typescriptcompiler&quot;,
-    &quot;ts.external.directory.path&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Attach to Node.js/Chrome.Debug in Chrome.executor": "Debug",
+    "JavaScript Debug.Debug in Chrome.executor": "Debug",
+    "RunOnceActivity.OpenDatabaseViewOnStart": "true",
+    "RunOnceActivity.OpenProjectViewOnStart": "true",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "RunOnceActivity.git.unshallow": "true",
+    "Vitest.All Tests.executor": "Run",
+    "Vitest.Content utilities.Parse a localised form data object into a localised value object.executor": "Run",
+    "Vitest.Content utilities.Retrieve the number of errors for each localised field.executor": "Run",
+    "Vitest.Content utilities.executor": "Run",
+    "Vitest.Validating the page.executor": "Run",
+    "Vitest.parseURL.Return the correct url for \"/over-ons/team\".executor": "Debug",
+    "Vitest.parseURL.Return the correct urls for \"/contact\".executor": "Debug",
+    "Vitest.validateLogin.executor": "Run",
+    "Vitest.validateLogin.should return success: false when emailaddress is invalid.executor": "Run",
+    "Vitest.validateLogin.should return success: false when emailaddress is missing.executor": "Run",
+    "git-widget-placeholder": "feature/WAT-84__Hook__pages__into__crud__flow",
+    "javascript.nodejs.core.library.configured.version": "22.11.0",
+    "javascript.nodejs.core.library.typings.version": "22.9.0",
+    "last_opened_file_path": "/Users/lody/dev/projects/watershed-website/app/routes/_index",
+    "node.js.detected.package.standard": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.standard": "",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_interpreter_path": "node",
+    "nodejs_package_manager_path": "npm",
+    "npm.Dev.executor": "Debug",
+    "npm.Develop.executor": "Run",
+    "npm.Storybook.executor": "Debug",
+    "npm.db:generate.executor": "Run",
+    "npm.db:push:seed.executor": "Run",
+    "npm.dev:app.executor": "Debug",
+    "npm.dev:remix.executor": "Debug",
+    "npm.dev:storybook.executor": "Debug",
+    "npm.docker:start.executor": "Run",
+    "prettierjs.PrettierConfiguration.Package": "/Users/lody/dev/projects/watershed-website/node_modules/prettier",
+    "settings.editor.selected.configurable": "settings.typescriptcompiler",
+    "ts.external.directory.path": "/Applications/PhpStorm.app/Contents/plugins/javascript-plugin/jsLanguageServicesImpl/external",
+    "vue.rearranger.settings.migration": "true"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;DatabaseDriversLRU&quot;: [
-      &quot;postgresql&quot;
+  "keyToStringList": {
+    "DatabaseDriversLRU": [
+      "postgresql"
     ],
-    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
-      &quot;CSS&quot;,
-      &quot;Markdown&quot;,
-      &quot;TEXT&quot;,
-      &quot;XML&quot;
+    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
+      "CSS",
+      "Markdown",
+      "TEXT",
+      "XML"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/app/routes/_index" />
@@ -384,15 +383,7 @@
       <workItem from="1744186455792" duration="6845000" />
       <workItem from="1744269733595" duration="10876000" />
       <workItem from="1744286517948" duration="11011000" />
-      <workItem from="1744356213721" duration="4577000" />
-    </task>
-    <task id="LOCAL-00078" summary="Refactored the account menu into a separate component and added admin/ route">
-      <option name="closed" value="true" />
-      <created>1741784759857</created>
-      <option name="number" value="00078" />
-      <option name="presentableId" value="LOCAL-00078" />
-      <option name="project" value="LOCAL" />
-      <updated>1741784759857</updated>
+      <workItem from="1744356213721" duration="5331000" />
     </task>
     <task id="LOCAL-00079" summary="Created the dynamic content route, and added a basic implementation of the content table.">
       <option name="closed" value="true" />
@@ -778,7 +769,15 @@
       <option name="project" value="LOCAL" />
       <updated>1744358709945</updated>
     </task>
-    <option name="localTasksCounter" value="127" />
+    <task id="LOCAL-00127" summary="The slug can now also be set in Puck">
+      <option name="closed" value="true" />
+      <created>1744362418411</created>
+      <option name="number" value="00127" />
+      <option name="presentableId" value="LOCAL-00127" />
+      <option name="project" value="LOCAL" />
+      <updated>1744362418411</updated>
+    </task>
+    <option name="localTasksCounter" value="128" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -821,7 +820,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
     <MESSAGE value="GH Actions now performs a build on normal push" />
     <MESSAGE value="Enabled the UPDATE flow end to end." />
     <MESSAGE value="Renamed news link to events" />
@@ -846,7 +844,8 @@
     <MESSAGE value="Created &quot;new&quot; flow for generic pages." />
     <MESSAGE value="PageMutationForm now also shows errors, and made slug unique in prisma" />
     <MESSAGE value="Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged." />
-    <option name="LAST_COMMIT_MESSAGE" value="Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged." />
+    <MESSAGE value="The slug can now also be set in Puck" />
+    <option name="LAST_COMMIT_MESSAGE" value="The slug can now also be set in Puck" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,19 +4,14 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Improvements to the header and anchor">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally.">
+      <change afterPath="$PROJECT_DIR$/app/validations/models/page.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/ContentTable.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/ContentTable.translations.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/models/pages.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/pages.server.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageEditor.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.stories.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageEditor.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/config/blocks/HeadingBlock.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/blocks/HeadingBlock.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/config/puck.config.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/puck.config.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/AdminMenu.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/AdminMenu.translations.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/AdminMenu.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/AdminMenu.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/_index/_index.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/_index/_index.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/types/Content.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/types/Content.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/package.json" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -44,12 +39,12 @@
               <option name="branches">
                 <list>
                   <RecentBranch>
-                    <option name="branchName" value="feature/WAT-83_Create_overview_route" />
-                    <option name="lastUsedInstant" value="1744183068" />
+                    <option name="branchName" value="feature/WAT-84_Hook_pages_into_crud_flow" />
+                    <option name="lastUsedInstant" value="1744185357" />
                   </RecentBranch>
                   <RecentBranch>
                     <option name="branchName" value="release/WAT-60_Create_CRUD_flow_for_generic_pages" />
-                    <option name="lastUsedInstant" value="1744183043" />
+                    <option name="lastUsedInstant" value="1744185222" />
                   </RecentBranch>
                   <RecentBranch>
                     <option name="branchName" value="dev" />
@@ -125,60 +120,60 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Attach to Node.js/Chrome.Debug in Chrome.executor": "Debug",
-    "JavaScript Debug.Debug in Chrome.executor": "Debug",
-    "RunOnceActivity.OpenDatabaseViewOnStart": "true",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "Vitest.All Tests.executor": "Run",
-    "Vitest.Content utilities.Parse a localised form data object into a localised value object.executor": "Run",
-    "Vitest.Content utilities.Retrieve the number of errors for each localised field.executor": "Run",
-    "Vitest.Content utilities.executor": "Run",
-    "Vitest.parseURL.Return the correct url for \"/over-ons/team\".executor": "Debug",
-    "Vitest.parseURL.Return the correct urls for \"/contact\".executor": "Debug",
-    "Vitest.validateLogin.executor": "Run",
-    "Vitest.validateLogin.should return success: false when emailaddress is invalid.executor": "Run",
-    "Vitest.validateLogin.should return success: false when emailaddress is missing.executor": "Run",
-    "git-widget-placeholder": "feature/WAT-83__Create__overview__route",
-    "javascript.nodejs.core.library.configured.version": "22.11.0",
-    "javascript.nodejs.core.library.typings.version": "22.9.0",
-    "last_opened_file_path": "/Users/lody/dev/projects/watershed-website/app/routes/_index",
-    "node.js.detected.package.standard": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.standard": "",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_interpreter_path": "node",
-    "nodejs_package_manager_path": "npm",
-    "npm.Dev.executor": "Debug",
-    "npm.Develop.executor": "Run",
-    "npm.Storybook.executor": "Debug",
-    "npm.db:generate.executor": "Run",
-    "npm.db:push:seed.executor": "Run",
-    "npm.dev:app.executor": "Debug",
-    "npm.dev:remix.executor": "Debug",
-    "npm.dev:storybook.executor": "Debug",
-    "npm.docker:start.executor": "Run",
-    "prettierjs.PrettierConfiguration.Package": "/Users/lody/dev/projects/watershed-website/node_modules/prettier",
-    "settings.editor.selected.configurable": "settings.typescriptcompiler",
-    "ts.external.directory.path": "/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Attach to Node.js/Chrome.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
+    &quot;JavaScript Debug.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
+    &quot;RunOnceActivity.OpenDatabaseViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;Vitest.All Tests.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.Parse a localised form data object into a localised value object.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.Retrieve the number of errors for each localised field.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.parseURL.Return the correct url for \&quot;/over-ons/team\&quot;.executor&quot;: &quot;Debug&quot;,
+    &quot;Vitest.parseURL.Return the correct urls for \&quot;/contact\&quot;.executor&quot;: &quot;Debug&quot;,
+    &quot;Vitest.validateLogin.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.should return success: false when emailaddress is invalid.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.should return success: false when emailaddress is missing.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/WAT-84__Hook__pages__into__crud__flow&quot;,
+    &quot;javascript.nodejs.core.library.configured.version&quot;: &quot;22.11.0&quot;,
+    &quot;javascript.nodejs.core.library.typings.version&quot;: &quot;22.9.0&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/lody/dev/projects/watershed-website/app/routes/_index&quot;,
+    &quot;node.js.detected.package.standard&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.standard&quot;: &quot;&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_interpreter_path&quot;: &quot;node&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;npm.Dev.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.Develop.executor&quot;: &quot;Run&quot;,
+    &quot;npm.Storybook.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.db:generate.executor&quot;: &quot;Run&quot;,
+    &quot;npm.db:push:seed.executor&quot;: &quot;Run&quot;,
+    &quot;npm.dev:app.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:remix.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:storybook.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.docker:start.executor&quot;: &quot;Run&quot;,
+    &quot;prettierjs.PrettierConfiguration.Package&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/prettier&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;settings.typescriptcompiler&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   },
-  "keyToStringList": {
-    "DatabaseDriversLRU": [
-      "postgresql"
+  &quot;keyToStringList&quot;: {
+    &quot;DatabaseDriversLRU&quot;: [
+      &quot;postgresql&quot;
     ],
-    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
-      "CSS",
-      "Markdown",
-      "TEXT",
-      "XML"
+    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
+      &quot;CSS&quot;,
+      &quot;Markdown&quot;,
+      &quot;TEXT&quot;,
+      &quot;XML&quot;
     ]
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/app/routes/_index" />
@@ -388,15 +383,8 @@
       <workItem from="1744104003640" duration="30000" />
       <workItem from="1744107218447" duration="215000" />
       <workItem from="1744109617972" duration="1204000" />
-      <workItem from="1744182959032" duration="1711000" />
-    </task>
-    <task id="LOCAL-00072" summary="Changed scripts">
-      <option name="closed" value="true" />
-      <created>1741703575084</created>
-      <option name="number" value="00072" />
-      <option name="presentableId" value="LOCAL-00072" />
-      <option name="project" value="LOCAL" />
-      <updated>1741703575084</updated>
+      <workItem from="1744182959032" duration="3484000" />
+      <workItem from="1744186455792" duration="5439000" />
     </task>
     <task id="LOCAL-00073" summary="Last changes in order to switch to React Router v7">
       <option name="closed" value="true" />
@@ -782,7 +770,15 @@
       <option name="project" value="LOCAL" />
       <updated>1743544618451</updated>
     </task>
-    <option name="localTasksCounter" value="121" />
+    <task id="LOCAL-00121" summary="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally.">
+      <option name="closed" value="true" />
+      <created>1744184819879</created>
+      <option name="number" value="00121" />
+      <option name="presentableId" value="LOCAL-00121" />
+      <option name="project" value="LOCAL" />
+      <updated>1744184819879</updated>
+    </task>
+    <option name="localTasksCounter" value="122" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -825,7 +821,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Enhance EventMutationForm with locale support and local storage integration, also added a locale selector component." />
     <MESSAGE value="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting." />
     <MESSAGE value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
     <MESSAGE value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
@@ -850,7 +845,8 @@
     <MESSAGE value="Added link to user account in header" />
     <MESSAGE value="Fixed color declarations across Tailwind, Shoelace and the app" />
     <MESSAGE value="Improvements to the header and anchor" />
-    <option name="LAST_COMMIT_MESSAGE" value="Improvements to the header and anchor" />
+    <MESSAGE value="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally." />
+    <option name="LAST_COMMIT_MESSAGE" value="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,14 +4,25 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally.">
-      <change afterPath="$PROJECT_DIR$/app/validations/models/page.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Reworked the Puck editor to support for page/SEO metadata.">
+      <change afterPath="$PROJECT_DIR$/app/validations/models/page.test.ts" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/PageEditor.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.stories.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/components/PageEditor.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/config/blocks/HeadingBlock.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/blocks/HeadingBlock.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageRenderer.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageRenderer.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/config/puck.config.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/puck.config.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/models/pages.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/pages.server.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/$/_pages.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/$/_pages.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.translations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/routes/_index/_home.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/_index/_home.tsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/validations/models/page.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/page.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/prisma/schema.prisma" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/schema.prisma" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/prisma/seed/_content.ts" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/seed/_content.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/prisma/seed/_pageContent.ts" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/seed/_pageContent.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -132,6 +143,7 @@
     &quot;Vitest.Content utilities.Parse a localised form data object into a localised value object.executor&quot;: &quot;Run&quot;,
     &quot;Vitest.Content utilities.Retrieve the number of errors for each localised field.executor&quot;: &quot;Run&quot;,
     &quot;Vitest.Content utilities.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Validating the page.executor&quot;: &quot;Run&quot;,
     &quot;Vitest.parseURL.Return the correct url for \&quot;/over-ons/team\&quot;.executor&quot;: &quot;Debug&quot;,
     &quot;Vitest.parseURL.Return the correct urls for \&quot;/contact\&quot;.executor&quot;: &quot;Debug&quot;,
     &quot;Vitest.validateLogin.executor&quot;: &quot;Run&quot;,
@@ -219,17 +231,16 @@
       <scope-kind value="ALL" />
       <method v="2" />
     </configuration>
-    <configuration name="Content utilities.Parse a localised form data object into a localised value object" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
+    <configuration name="Validating the page" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
       <node-interpreter value="project" />
       <vitest-package value="$PROJECT_DIR$/node_modules/vitest" />
       <working-dir value="$PROJECT_DIR$" />
       <vitest-options value="--run" />
       <envs />
       <scope-kind value="TEST" />
-      <test-file value="$PROJECT_DIR$/app/utils/content.test.ts" />
+      <test-file value="$PROJECT_DIR$/app/validations/models/page.test.ts" />
       <test-names>
-        <test-name value="Content utilities" />
-        <test-name value="Parse a localised form data object into a localised value object" />
+        <test-name value="Validating the page" />
       </test-names>
       <method v="2" />
     </configuration>
@@ -313,17 +324,17 @@
       <item itemvalue="npm.db:generate" />
       <item itemvalue="npm.db:push:seed" />
       <item itemvalue="Vitest.All Tests" />
+      <item itemvalue="Vitest.Validating the page" />
       <item itemvalue="Vitest.parseURL.Return the correct url for &quot;/over-ons/team&quot;" />
       <item itemvalue="Vitest.parseURL.Return the correct urls for &quot;/contact&quot;" />
-      <item itemvalue="Vitest.Content utilities.Parse a localised form data object into a localised value object" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="Vitest.Validating the page" />
         <item itemvalue="npm.db:push:seed" />
         <item itemvalue="npm.db:generate" />
         <item itemvalue="Vitest.parseURL.Return the correct url for &quot;/over-ons/team&quot;" />
         <item itemvalue="Vitest.parseURL.Return the correct urls for &quot;/contact&quot;" />
-        <item itemvalue="Vitest.Content utilities.Parse a localised form data object into a localised value object" />
       </list>
     </recent_temporary>
   </component>
@@ -384,15 +395,9 @@
       <workItem from="1744107218447" duration="215000" />
       <workItem from="1744109617972" duration="1204000" />
       <workItem from="1744182959032" duration="3484000" />
-      <workItem from="1744186455792" duration="5439000" />
-    </task>
-    <task id="LOCAL-00073" summary="Last changes in order to switch to React Router v7">
-      <option name="closed" value="true" />
-      <created>1741704156871</created>
-      <option name="number" value="00073" />
-      <option name="presentableId" value="LOCAL-00073" />
-      <option name="project" value="LOCAL" />
-      <updated>1741704156871</updated>
+      <workItem from="1744186455792" duration="6845000" />
+      <workItem from="1744269733595" duration="10876000" />
+      <workItem from="1744286517948" duration="6542000" />
     </task>
     <task id="LOCAL-00074" summary="Refine route configuration and update dependencies">
       <option name="closed" value="true" />
@@ -778,7 +783,15 @@
       <option name="project" value="LOCAL" />
       <updated>1744184819879</updated>
     </task>
-    <option name="localTasksCounter" value="122" />
+    <task id="LOCAL-00122" summary="Reworked the Puck editor to support for page/SEO metadata.">
+      <option name="closed" value="true" />
+      <created>1744195214320</created>
+      <option name="number" value="00122" />
+      <option name="presentableId" value="LOCAL-00122" />
+      <option name="project" value="LOCAL" />
+      <updated>1744195214321</updated>
+    </task>
+    <option name="localTasksCounter" value="123" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -821,7 +834,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Refactor EventMutationForm to support localization and improve error handling, including new utility functions for form data transformation and error counting." />
     <MESSAGE value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
     <MESSAGE value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
     <MESSAGE value="Fixed a lot of lint and typecheck errors" />
@@ -846,7 +858,20 @@
     <MESSAGE value="Fixed color declarations across Tailwind, Shoelace and the app" />
     <MESSAGE value="Improvements to the header and anchor" />
     <MESSAGE value="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally." />
-    <option name="LAST_COMMIT_MESSAGE" value="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally." />
+    <MESSAGE value="Reworked the Puck editor to support for page/SEO metadata." />
+    <option name="LAST_COMMIT_MESSAGE" value="Reworked the Puck editor to support for page/SEO metadata." />
+  </component>
+  <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint enabled="true" type="javascript">
+          <url>file://$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx</url>
+          <line>57</line>
+          <properties lambdaOrdinal="-1" />
+          <option name="timeStamp" value="13" />
+        </line-breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Pages can now be edited and saved  Also added slugs to seeding scripts">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Changed some of the navigation labels">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.translations.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/models/pages.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/pages.server.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -382,15 +382,7 @@
       <workItem from="1744186455792" duration="6845000" />
       <workItem from="1744269733595" duration="10876000" />
       <workItem from="1744286517948" duration="11011000" />
-      <workItem from="1744356213721" duration="7443000" />
-    </task>
-    <task id="LOCAL-00082" summary="Created all needed routes for CRUD functionality.">
-      <option name="closed" value="true" />
-      <created>1741869436229</created>
-      <option name="number" value="00082" />
-      <option name="presentableId" value="LOCAL-00082" />
-      <option name="project" value="LOCAL" />
-      <updated>1741869436229</updated>
+      <workItem from="1744356213721" duration="7920000" />
     </task>
     <task id="LOCAL-00083" summary="Code quality improvements, including running a type check on CI/CD">
       <option name="closed" value="true" />
@@ -776,7 +768,15 @@
       <option name="project" value="LOCAL" />
       <updated>1744364119344</updated>
     </task>
-    <option name="localTasksCounter" value="131" />
+    <task id="LOCAL-00131" summary="Changed some of the navigation labels">
+      <option name="closed" value="true" />
+      <created>1744365268366</created>
+      <option name="number" value="00131" />
+      <option name="presentableId" value="LOCAL-00131" />
+      <option name="project" value="LOCAL" />
+      <updated>1744365268366</updated>
+    </task>
+    <option name="localTasksCounter" value="132" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -819,7 +819,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Moved the components from the news route to the generic components folder as they can be reused." />
     <MESSAGE value="Removed the news routes" />
     <MESSAGE value="Added fonts and setup styles for the heading" />
     <MESSAGE value="Removed more references to the News" />
@@ -844,7 +843,8 @@
     <MESSAGE value="DB diff script is runnable from npm and fixed the wrong port check method." />
     <MESSAGE value="Ran prisma migrate to updated db to new schema" />
     <MESSAGE value="Pages can now be edited and saved  Also added slugs to seeding scripts" />
-    <option name="LAST_COMMIT_MESSAGE" value="Pages can now be edited and saved  Also added slugs to seeding scripts" />
+    <MESSAGE value="Changed some of the navigation labels" />
+    <option name="LAST_COMMIT_MESSAGE" value="Changed some of the navigation labels" />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,8 +4,9 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Changed some of the navigation labels">
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Added page summary to the content table">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageRenderer.stories.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageRenderer.stories.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/app/models/pages.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/pages.server.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -70,6 +71,7 @@
 }</component>
   <component name="HighlightingSettingsPerFile">
     <setting file="file://$PROJECT_DIR$/node_modules/@shoelace-style/shoelace/dist/components/button/button.d.ts" root0="SKIP_INSPECTION" />
+    <setting file="file://$PROJECT_DIR$/node_modules/zod/lib/types.d.ts" root0="SKIP_INSPECTION" />
   </component>
   <component name="KubernetesApiPersistence">{}</component>
   <component name="KubernetesApiProvider">{
@@ -115,61 +117,62 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Attach to Node.js/Chrome.Debug in Chrome.executor": "Debug",
-    "JavaScript Debug.Debug in Chrome.executor": "Debug",
-    "RunOnceActivity.OpenDatabaseViewOnStart": "true",
-    "RunOnceActivity.OpenProjectViewOnStart": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "Vitest.All Tests.executor": "Run",
-    "Vitest.Content utilities.Parse a localised form data object into a localised value object.executor": "Run",
-    "Vitest.Content utilities.Retrieve the number of errors for each localised field.executor": "Run",
-    "Vitest.Content utilities.executor": "Run",
-    "Vitest.Validating the page.executor": "Run",
-    "Vitest.parseURL.Return the correct url for \"/over-ons/team\".executor": "Debug",
-    "Vitest.parseURL.Return the correct urls for \"/contact\".executor": "Debug",
-    "Vitest.validateLogin.executor": "Run",
-    "Vitest.validateLogin.should return success: false when emailaddress is invalid.executor": "Run",
-    "Vitest.validateLogin.should return success: false when emailaddress is missing.executor": "Run",
-    "git-widget-placeholder": "feature/WAT-84__Hook__pages__into__crud__flow",
-    "javascript.nodejs.core.library.configured.version": "22.11.0",
-    "javascript.nodejs.core.library.typings.version": "22.9.0",
-    "last_opened_file_path": "/Users/lody/dev/projects/watershed-website/app/routes/_index",
-    "node.js.detected.package.standard": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.standard": "",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_interpreter_path": "node",
-    "nodejs_package_manager_path": "npm",
-    "npm.Dev.executor": "Debug",
-    "npm.Develop.executor": "Run",
-    "npm.Storybook.executor": "Debug",
-    "npm.db:generate.executor": "Run",
-    "npm.db:push:seed.executor": "Run",
-    "npm.dev:app.executor": "Debug",
-    "npm.dev:remix.executor": "Debug",
-    "npm.dev:storybook.executor": "Debug",
-    "npm.docker:start.executor": "Run",
-    "prettierjs.PrettierConfiguration.Package": "/Users/lody/dev/projects/watershed-website/node_modules/prettier",
-    "settings.editor.selected.configurable": "settings.typescriptcompiler",
-    "ts.external.directory.path": "/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Attach to Node.js/Chrome.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
+    &quot;JavaScript Debug.Debug in Chrome.executor&quot;: &quot;Debug&quot;,
+    &quot;RunOnceActivity.OpenDatabaseViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;Vitest.All Tests.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.Parse a localised form data object into a localised value object.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.Retrieve the number of errors for each localised field.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Content utilities.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.Validating the page.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.parseURL.Return the correct url for \&quot;/over-ons/team\&quot;.executor&quot;: &quot;Debug&quot;,
+    &quot;Vitest.parseURL.Return the correct urls for \&quot;/contact\&quot;.executor&quot;: &quot;Debug&quot;,
+    &quot;Vitest.validateLogin.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.should return success: false when emailaddress is invalid.executor&quot;: &quot;Run&quot;,
+    &quot;Vitest.validateLogin.should return success: false when emailaddress is missing.executor&quot;: &quot;Run&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;feature/WAT-84__Hook__pages__into__crud__flow&quot;,
+    &quot;javascript.nodejs.core.library.configured.version&quot;: &quot;22.11.0&quot;,
+    &quot;javascript.nodejs.core.library.typings.version&quot;: &quot;22.9.0&quot;,
+    &quot;last_opened_file_path&quot;: &quot;/Users/lody/dev/projects/watershed-website/app/routes/_index&quot;,
+    &quot;node.js.detected.package.standard&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.standard&quot;: &quot;&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_interpreter_path&quot;: &quot;node&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;npm.Dev.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.Develop.executor&quot;: &quot;Run&quot;,
+    &quot;npm.Storybook.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.db:generate.executor&quot;: &quot;Run&quot;,
+    &quot;npm.db:push:seed.executor&quot;: &quot;Run&quot;,
+    &quot;npm.dev:app.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:remix.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.dev:storybook.executor&quot;: &quot;Debug&quot;,
+    &quot;npm.docker:start.executor&quot;: &quot;Run&quot;,
+    &quot;npm.typecheck.executor&quot;: &quot;Run&quot;,
+    &quot;prettierjs.PrettierConfiguration.Package&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/prettier&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;settings.typescriptcompiler&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;/Users/lody/dev/projects/watershed-website/node_modules/typescript/lib&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   },
-  "keyToStringList": {
-    "DatabaseDriversLRU": [
-      "postgresql"
+  &quot;keyToStringList&quot;: {
+    &quot;DatabaseDriversLRU&quot;: [
+      &quot;postgresql&quot;
     ],
-    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
-      "CSS",
-      "Markdown",
-      "TEXT",
-      "XML"
+    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
+      &quot;CSS&quot;,
+      &quot;Markdown&quot;,
+      &quot;TEXT&quot;,
+      &quot;XML&quot;
     ]
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/app/routes/_index" />
@@ -200,7 +203,7 @@
       <command value="npm run db:push:seed" />
     </option>
   </component>
-  <component name="RunManager" selected="Compound.Develop">
+  <component name="RunManager" selected="npm.typecheck">
     <configuration name="Develop" type="CompoundRunConfigurationType">
       <toRun name="Dev" type="js.build_tools.npm" />
       <toRun name="Storybook" type="js.build_tools.npm" />
@@ -239,20 +242,6 @@
       <test-names>
         <test-name value="parseURL" />
         <test-name value="Return the correct url for &quot;/over-ons/team&quot;" />
-      </test-names>
-      <method v="2" />
-    </configuration>
-    <configuration name="parseURL.Return the correct urls for &quot;/contact&quot;" type="JavaScriptTestRunnerVitest" temporary="true" nameIsGenerated="true">
-      <node-interpreter value="project" />
-      <vitest-package value="$PROJECT_DIR$/node_modules/vitest" />
-      <working-dir value="$PROJECT_DIR$" />
-      <vitest-options value="--run" />
-      <envs />
-      <scope-kind value="TEST" />
-      <test-file value="$PROJECT_DIR$/app/utils/slug.test.ts" />
-      <test-names>
-        <test-name value="parseURL" />
-        <test-name value="Return the correct urls for &quot;/contact&quot;" />
       </test-names>
       <method v="2" />
     </configuration>
@@ -300,25 +289,35 @@
       <envs />
       <method v="2" />
     </configuration>
+    <configuration name="typecheck" type="js.build_tools.npm" temporary="true" nameIsGenerated="true">
+      <package-json value="$PROJECT_DIR$/package.json" />
+      <command value="run" />
+      <scripts>
+        <script value="typecheck" />
+      </scripts>
+      <node-interpreter value="project" />
+      <envs />
+      <method v="2" />
+    </configuration>
     <list>
       <item itemvalue="Compound.Develop" />
       <item itemvalue="JavaScript Debug.Debug in Chrome" />
       <item itemvalue="npm.Dev" />
       <item itemvalue="npm.Storybook" />
+      <item itemvalue="npm.typecheck" />
       <item itemvalue="npm.db:generate" />
       <item itemvalue="npm.db:push:seed" />
       <item itemvalue="Vitest.All Tests" />
       <item itemvalue="Vitest.Validating the page" />
       <item itemvalue="Vitest.parseURL.Return the correct url for &quot;/over-ons/team&quot;" />
-      <item itemvalue="Vitest.parseURL.Return the correct urls for &quot;/contact&quot;" />
     </list>
     <recent_temporary>
       <list>
+        <item itemvalue="npm.typecheck" />
         <item itemvalue="Vitest.Validating the page" />
         <item itemvalue="npm.db:push:seed" />
         <item itemvalue="npm.db:generate" />
         <item itemvalue="Vitest.parseURL.Return the correct url for &quot;/over-ons/team&quot;" />
-        <item itemvalue="Vitest.parseURL.Return the correct urls for &quot;/contact&quot;" />
       </list>
     </recent_temporary>
   </component>
@@ -383,6 +382,7 @@
       <workItem from="1744269733595" duration="10876000" />
       <workItem from="1744286517948" duration="11011000" />
       <workItem from="1744356213721" duration="7920000" />
+      <workItem from="1744375081403" duration="282000" />
     </task>
     <task id="LOCAL-00083" summary="Code quality improvements, including running a type check on CI/CD">
       <option name="closed" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,25 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Reworked the Puck editor to support for page/SEO metadata.">
-      <change afterPath="$PROJECT_DIR$/app/validations/models/page.test.ts" afterDir="false" />
+    <list default="true" id="7f955583-8571-46fe-bf73-823af2e4bb22" name="Changes" comment="Created &quot;new&quot; flow for generic pages.">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/PageEditor.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageEditor.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/components/PageRenderer.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageRenderer.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/config/puck.config.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/config/puck.config.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/en.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/en.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/locales/nl.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/locales/nl.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/models/pages.server.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/models/pages.server.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/$/_pages.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/$/_pages.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.translations.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.translations.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/account/AccountMenu.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/_index/_overview.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/routes/_index/_home.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/routes/_index/_home.tsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/app/validations/models/page.ts" beforeDir="false" afterPath="$PROJECT_DIR$/app/validations/models/page.ts" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/app/components/PageMutationForm.tsx" beforeDir="false" afterPath="$PROJECT_DIR$/app/components/PageMutationForm.tsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/prisma/schema.prisma" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/schema.prisma" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/prisma/seed/_content.ts" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/seed/_content.ts" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/prisma/seed/_pageContent.ts" beforeDir="false" afterPath="$PROJECT_DIR$/prisma/seed/_pageContent.ts" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -397,23 +382,7 @@
       <workItem from="1744182959032" duration="3484000" />
       <workItem from="1744186455792" duration="6845000" />
       <workItem from="1744269733595" duration="10876000" />
-      <workItem from="1744286517948" duration="6542000" />
-    </task>
-    <task id="LOCAL-00074" summary="Refine route configuration and update dependencies">
-      <option name="closed" value="true" />
-      <created>1741774743058</created>
-      <option name="number" value="00074" />
-      <option name="presentableId" value="LOCAL-00074" />
-      <option name="project" value="LOCAL" />
-      <updated>1741774743058</updated>
-    </task>
-    <task id="LOCAL-00075" summary="Removed some testing code I forgot to delete.">
-      <option name="closed" value="true" />
-      <created>1741776400952</created>
-      <option name="number" value="00075" />
-      <option name="presentableId" value="LOCAL-00075" />
-      <option name="project" value="LOCAL" />
-      <updated>1741776400952</updated>
+      <workItem from="1744286517948" duration="10065000" />
     </task>
     <task id="LOCAL-00076" summary="Setup basic account page structure so that we can start with the admin work">
       <option name="closed" value="true" />
@@ -791,7 +760,23 @@
       <option name="project" value="LOCAL" />
       <updated>1744195214321</updated>
     </task>
-    <option name="localTasksCounter" value="123" />
+    <task id="LOCAL-00123" summary="Created &quot;new&quot; flow for generic pages.">
+      <option name="closed" value="true" />
+      <created>1744293214432</created>
+      <option name="number" value="00123" />
+      <option name="presentableId" value="LOCAL-00123" />
+      <option name="project" value="LOCAL" />
+      <updated>1744293214433</updated>
+    </task>
+    <task id="LOCAL-00124" summary="Created &quot;new&quot; flow for generic pages.">
+      <option name="closed" value="true" />
+      <created>1744293439309</created>
+      <option name="number" value="00124" />
+      <option name="presentableId" value="LOCAL-00124" />
+      <option name="project" value="LOCAL" />
+      <updated>1744293439309</updated>
+    </task>
+    <option name="localTasksCounter" value="125" />
     <servers />
   </component>
   <component name="TerminalProjectNonSharedOptionsProvider">
@@ -834,7 +819,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Add LocalisedInput component and enhance LocaleSelector with new props and event handling" />
     <MESSAGE value="Add DeepPartial type and LocalisedInput component; refactor EventMutationForm for improved localization and error handling" />
     <MESSAGE value="Fixed a lot of lint and typecheck errors" />
     <MESSAGE value="Simplified the component tests for Event Mutation Form and updated Project Mutation Form following the same workflow as the EMF" />
@@ -859,19 +843,8 @@
     <MESSAGE value="Improvements to the header and anchor" />
     <MESSAGE value="Pages are now served from the content overview route as well, and can be accessed from the admin menu. A &quot;qa&quot; script is added to run a small and full qa control locally." />
     <MESSAGE value="Reworked the Puck editor to support for page/SEO metadata." />
-    <option name="LAST_COMMIT_MESSAGE" value="Reworked the Puck editor to support for page/SEO metadata." />
-  </component>
-  <component name="XDebuggerManager">
-    <breakpoint-manager>
-      <breakpoints>
-        <line-breakpoint enabled="true" type="javascript">
-          <url>file://$PROJECT_DIR$/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx</url>
-          <line>57</line>
-          <properties lambdaOrdinal="-1" />
-          <option name="timeStamp" value="13" />
-        </line-breakpoint>
-      </breakpoints>
-    </breakpoint-manager>
+    <MESSAGE value="Created &quot;new&quot; flow for generic pages." />
+    <option name="LAST_COMMIT_MESSAGE" value="Created &quot;new&quot; flow for generic pages." />
   </component>
   <component name="XSLT-Support.FileAssociations.UIState">
     <expand />

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -12,7 +12,7 @@ import '../app/tailwind.css';
 import './viewer.css';
 
 const preview: Preview = {
-  tags: ['autodocs', 'autodocs'],
+  tags: ['autodocs'],
   parameters: {
     i18n,
     backgrounds: {
@@ -46,7 +46,15 @@ const preview: Preview = {
     },
     options: {
       storySort: {
-        order: ['Introduction', 'Brand', 'Components', 'Forms'],
+        order: [
+          'Introduction',
+          'Brand',
+          'Atoms',
+          'Molecules',
+          'Organisms',
+          'Forms',
+          'Templates',
+        ],
       },
     },
   },

--- a/app/components/Anchor.stories.ts
+++ b/app/components/Anchor.stories.ts
@@ -2,8 +2,9 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import Anchor from './Anchor';
 
 export default {
-  title: 'Components/Anchor',
+  title: 'Atoms/Anchor',
   component: Anchor,
+  tags: ['components', 'navigation'],
 } satisfies Meta<typeof Anchor>;
 
 type Story = StoryObj<typeof Anchor>;

--- a/app/components/ArticleCard.stories.tsx
+++ b/app/components/ArticleCard.stories.tsx
@@ -5,8 +5,9 @@ import { convertDateToLocaleString } from '~/utils/date';
 import { Tag } from '~/components/Tags';
 
 export default {
-  title: 'Components/News Article Card',
+  title: 'Organisms/News Article Card',
   component: ArticleCard,
+  tags: ['components', 'deprecated', 'news'],
 } satisfies Meta<typeof ArticleCard>;
 
 type Story = StoryObj<typeof ArticleCard>;

--- a/app/components/ArtistProfileSummary.stories.tsx
+++ b/app/components/ArtistProfileSummary.stories.tsx
@@ -3,9 +3,9 @@ import { faker } from '@faker-js/faker';
 import ArtistProfileSummary from './ArtistProfileSummary';
 
 export default {
-  title: 'Components/Artist Profile Summary',
+  title: 'Organisms/Artist Profile Summary',
   component: ArtistProfileSummary,
-  tags: ['news'],
+  tags: ['components', 'artists'],
 } satisfies Meta<typeof ArtistProfileSummary>;
 
 type Story = StoryObj<typeof ArtistProfileSummary>;

--- a/app/components/ArtistsSummary.stories.tsx
+++ b/app/components/ArtistsSummary.stories.tsx
@@ -4,9 +4,9 @@ import ArtistsSummary from './ArtistsSummary';
 import { Props as ArtistProfileSummaryProps } from './ArtistProfileSummary';
 
 export default {
-  title: 'Components/Artists Summary',
+  title: 'Organisms/Artists Summary',
   component: ArtistsSummary,
-  tags: ['news'],
+  tags: ['components', 'artists'],
 } satisfies Meta<typeof ArtistsSummary>;
 
 type Story = StoryObj<typeof ArtistsSummary>;

--- a/app/components/Breadcrumbs.stories.ts
+++ b/app/components/Breadcrumbs.stories.ts
@@ -3,8 +3,9 @@ import Breadcrumbs from './Breadcrumbs';
 import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 
 export default {
-  title: 'Components/Breadcrumbs',
+  title: 'Molecules/Breadcrumbs',
   component: Breadcrumbs,
+  tags: ['components', 'navigation'],
 } satisfies Meta<typeof Breadcrumbs>;
 
 type Story = StoryObj<typeof Breadcrumbs>;

--- a/app/components/ChangePasswordForm.stories.tsx
+++ b/app/components/ChangePasswordForm.stories.tsx
@@ -7,6 +7,7 @@ export default {
   decorators: [
     (Story) => <div className="w-full max-w-[35rem]">{Story()}</div>,
   ],
+  tags: ['components', 'authentication'],
 } satisfies Meta<typeof ChangePasswordForm>;
 
 type Story = StoryObj<typeof ChangePasswordForm>;

--- a/app/components/ContentTable.stories.tsx
+++ b/app/components/ContentTable.stories.tsx
@@ -3,8 +3,9 @@ import { fakerNL as faker } from '@faker-js/faker';
 import ContentTable, { ContentTableItem } from './ContentTable';
 
 export default {
-  title: 'Components/Content Table',
+  title: 'Organisms/Content Table',
   component: ContentTable,
+  tags: ['components', 'content'],
 } satisfies Meta<typeof ContentTable>;
 
 type Story = StoryObj<typeof ContentTable>;

--- a/app/components/DateInput.stories.tsx
+++ b/app/components/DateInput.stories.tsx
@@ -2,8 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import DateInput from './DateInput';
 
 export default {
-  title: 'Components/Date Input',
+  title: 'Atoms/Date Input',
   component: DateInput,
+  tags: ['components', 'input', 'shoelace'],
 } satisfies Meta<typeof DateInput>;
 
 type Story = StoryObj<typeof DateInput>;

--- a/app/components/EventMutationForm.stories.tsx
+++ b/app/components/EventMutationForm.stories.tsx
@@ -6,8 +6,9 @@ import { validateEvent } from '~/validations/models/event';
 import { expect, screen } from '@storybook/test';
 
 export default {
-  title: 'Components/Event Mutation Form',
+  title: 'Forms/Event Mutation Form',
   component: EventMutationForm,
+  tags: ['components', 'content'],
 } satisfies Meta<typeof EventMutationForm>;
 
 type Story = StoryObj<typeof EventMutationForm>;

--- a/app/components/EventSummary.stories.tsx
+++ b/app/components/EventSummary.stories.tsx
@@ -3,9 +3,9 @@ import { faker } from '@faker-js/faker';
 import EventSummary from './EventSummary';
 
 export default {
-  title: 'Components/Event Summary',
+  title: 'Organisms/Event Summary',
   component: EventSummary,
-  tags: ['news'],
+  tags: ['components', 'events'],
   decorators: [(Story) => <div className="w-1/3">{Story()}</div>],
 } satisfies Meta<typeof EventSummary>;
 

--- a/app/components/Header.stories.ts
+++ b/app/components/Header.stories.ts
@@ -4,8 +4,9 @@ import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 import { User } from '~/models/user.server';
 
 export default {
-  title: 'Components/Header',
+  title: 'Organisms/Header',
   component: Header,
+  tags: ['components', 'navigation'],
 } satisfies Meta<typeof Header>;
 
 type Story = StoryObj<typeof Header>;

--- a/app/components/Heading.stories.ts
+++ b/app/components/Heading.stories.ts
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import Heading from './Heading';
 
 export default {
-  title: 'Components/Heading',
+  title: 'Atoms/Heading',
   component: Heading,
   argTypes: {
     level: {
@@ -15,6 +15,7 @@ export default {
       },
     },
   },
+  tags: ['components', 'text'],
 } satisfies Meta<typeof Heading>;
 
 type Story = StoryObj<typeof Heading>;

--- a/app/components/Input.stories.tsx
+++ b/app/components/Input.stories.tsx
@@ -2,7 +2,7 @@ import { type Meta, type StoryObj } from '@storybook/react';
 import Input from './Input';
 
 export default {
-  title: 'Components/Input',
+  title: 'Atoms/Input',
   component: Input,
   decorators: [
     (Story) => (
@@ -11,6 +11,7 @@ export default {
       </div>
     ),
   ],
+  tags: ['components', 'input', 'shoelace'],
 } satisfies Meta<typeof Input>;
 
 type Story = StoryObj<typeof Input>;

--- a/app/components/LocaleSelector.stories.tsx
+++ b/app/components/LocaleSelector.stories.tsx
@@ -3,7 +3,7 @@ import LocaleSelector from './LocaleSelector';
 import { expect, fn, userEvent, waitFor, within } from '@storybook/test';
 
 export default {
-  title: 'Components/Locale Selector',
+  title: 'Molecules/Locale Selector',
   component: LocaleSelector,
   decorators: [
     (Story) => (
@@ -12,6 +12,7 @@ export default {
       </div>
     ),
   ],
+  tags: ['components', 'shoelace', 'localisation'],
 } satisfies Meta<typeof LocaleSelector>;
 
 type Story = StoryObj<typeof LocaleSelector>;

--- a/app/components/LocalisedInput.stories.tsx
+++ b/app/components/LocalisedInput.stories.tsx
@@ -4,7 +4,7 @@ import { fn, waitFor, within, expect } from '@storybook/test';
 import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 
 export default {
-  title: 'Components/Localised Input',
+  title: 'Molecules/Localised Input',
   component: LocalisedInput,
   decorators: [
     (Story) => (
@@ -20,6 +20,7 @@ export default {
       },
     },
   },
+  tags: ['components', 'shoelace', 'input', 'localisation'],
 } satisfies Meta<typeof LocalisedInput>;
 
 type Story = StoryObj<typeof LocalisedInput>;

--- a/app/components/Logo.stories.tsx
+++ b/app/components/Logo.stories.tsx
@@ -2,8 +2,9 @@ import { Meta, StoryObj } from '@storybook/react';
 import Logo from './Logo';
 
 export default {
-  title: 'Components/Logo',
+  title: 'Atoms/Logo',
   component: Logo,
+  tags: ['components', 'navigation'],
 } satisfies Meta<typeof Logo>;
 
 type Story = StoryObj<typeof Logo>;

--- a/app/components/PageEditor.stories.tsx
+++ b/app/components/PageEditor.stories.tsx
@@ -4,7 +4,7 @@ import PageEditor from '~/components/PageEditor';
 import Header from '~/components/Header';
 
 export default {
-  title: 'Components/Page Editor',
+  title: 'Templates/Page Editor',
   component: PageEditor,
   parameters: {
     layout: 'fullscreen',
@@ -17,6 +17,7 @@ export default {
       </div>
     ),
   ],
+  tags: ['components', 'content'],
 } satisfies Meta<typeof PageEditor>;
 
 type Story = StoryObj<typeof PageEditor>;

--- a/app/components/PageEditor.stories.tsx
+++ b/app/components/PageEditor.stories.tsx
@@ -24,7 +24,9 @@ type Story = StoryObj<typeof PageEditor>;
 export const Default: Story = {
   args: {
     data: {
-      root: { props: { title: '' } },
+      root: {
+        props: { title: 'Hallo', summary: 'Dit is een beschrijving' },
+      },
       content: [
         {
           type: 'HeadingBlock',
@@ -32,7 +34,7 @@ export const Default: Story = {
             id: 'Heading-1694032984497',
             text: 'Welkom bij Watershed',
             align: 'center',
-            level: 1,
+            level: 2,
           },
         },
         {
@@ -61,5 +63,28 @@ export const Default: Story = {
       ],
     },
     onPublish: fn(),
+  },
+};
+
+export const EmptyEditor: Story = {
+  args: {
+    data: {
+      root: {
+        props: { title: 'Hallo Wereld!', summary: 'Dit is een pagina' },
+      },
+    },
+    onPublish: fn(),
+  },
+};
+
+export const Publishing: Story = {
+  args: {
+    data: {
+      root: {
+        props: { title: 'Hallo Wereld!', summary: 'Dit is een pagina' },
+      },
+    },
+    onPublish: fn(),
+    isSaving: true,
   },
 };

--- a/app/components/PageEditor.tsx
+++ b/app/components/PageEditor.tsx
@@ -9,12 +9,16 @@ import { Overrides, Puck, usePuck } from '@measured/puck';
 
 import '@measured/puck/puck.css';
 
-import { config } from '~/config/puck.config';
+import {
+  config,
+  WatershedPageConfig,
+  WatershedPageData,
+} from '~/config/puck.config';
 import { ShoelaceContext } from '~/components/shoelace';
 
-type PuckProps = ComponentProps<typeof Puck>;
+type PuckProps = ComponentProps<typeof Puck<WatershedPageConfig>>;
 type Props = {
-  data?: PuckProps['data'];
+  data?: WatershedPageData | object;
   onPublish: PuckProps['onPublish'];
   isSaving?: boolean;
   title: string;
@@ -124,7 +128,7 @@ function EditorHeader({
   isSaving,
   title,
 }: EditorHeaderProps) {
-  const { appState } = usePuck();
+  const { appState } = usePuck<WatershedPageConfig>();
   const { SlButton, SlIconButton, SlIcon } = useContext(ShoelaceContext);
 
   const publish = () => {

--- a/app/components/PageEditor.tsx
+++ b/app/components/PageEditor.tsx
@@ -17,6 +17,11 @@ type Props = {
   data?: PuckProps['data'];
   onPublish: PuckProps['onPublish'];
   isSaving?: boolean;
+  title: string;
+};
+
+type EditorHeaderProps = Pick<Props, 'onPublish' | 'isSaving' | 'title'> & {
+  handleDrawerOpen: (orientation: 'left' | 'right') => void;
 };
 
 const overrides: Partial<Overrides> = {
@@ -33,6 +38,7 @@ export default function PageEditor({
   data = {},
   onPublish,
   isSaving = false,
+  title,
 }: Props) {
   const { SlDrawer } = useContext(ShoelaceContext);
 
@@ -70,6 +76,7 @@ export default function PageEditor({
           onPublish={onPublish}
           handleDrawerOpen={handleDrawerOpen}
           isSaving={isSaving}
+          title={title}
         />
 
         <SlDrawer
@@ -115,11 +122,8 @@ function EditorHeader({
   onPublish,
   handleDrawerOpen,
   isSaving,
-}: {
-  onPublish: Props['onPublish'];
-  handleDrawerOpen: (orientation: 'left' | 'right') => void;
-  isSaving?: Props['isSaving'];
-}) {
+  title,
+}: EditorHeaderProps) {
   const { appState } = usePuck();
   const { SlButton, SlIconButton, SlIcon } = useContext(ShoelaceContext);
 
@@ -139,7 +143,7 @@ function EditorHeader({
             onClick={() => handleDrawerOpen('left')}
             className="text-xl"
           />
-          <h1 className="text-xl font-bold">Pagina bewerken</h1>
+          <h1 className="text-xl font-bold">{title}</h1>
         </div>
 
         <div className="flex flex-row gap-2 justify-center items-center">

--- a/app/components/PageEditor.tsx
+++ b/app/components/PageEditor.tsx
@@ -3,7 +3,6 @@ import {
   ReactNode,
   useContext,
   useEffect,
-  useMemo,
   useState,
 } from 'react';
 import { Overrides, Puck, usePuck } from '@measured/puck';
@@ -13,7 +12,12 @@ import '@measured/puck/puck.css';
 import { config } from '~/config/puck.config';
 import { ShoelaceContext } from '~/components/shoelace';
 
-type Props = Pick<ComponentProps<typeof Puck>, 'data' | 'onPublish'>;
+type PuckProps = ComponentProps<typeof Puck>;
+type Props = {
+  data?: PuckProps['data'];
+  onPublish: PuckProps['onPublish'];
+  isSaving?: boolean;
+};
 
 const overrides: Partial<Overrides> = {
   iframe: ({ children, document }) => {
@@ -25,13 +29,24 @@ const overrides: Partial<Overrides> = {
   },
 };
 
-export default function PageEditor({ data, onPublish }: Props) {
+export default function PageEditor({
+  data = {},
+  onPublish,
+  isSaving = false,
+}: Props) {
   const { SlDrawer } = useContext(ShoelaceContext);
 
-  const [open, setOpen] = useState(false);
+  const [leftDrawerOpen, setLeftDrawerOpen] = useState(false);
+  const [rightDrawerOpen, setRightDrawerOpen] = useState(false);
 
-  const handleDrawerOpen = () => {
-    setOpen(true);
+  const handleDrawerOpen = (orientation: 'left' | 'right') => {
+    if (orientation === 'left') {
+      setLeftDrawerOpen(true);
+    }
+
+    if (orientation === 'right') {
+      setRightDrawerOpen(true);
+    }
   };
 
   return (
@@ -43,9 +58,9 @@ export default function PageEditor({ data, onPublish }: Props) {
     >
       <div className="w-full h-full flex flex-col gap-4 px-4">
         <SlDrawer
-          open={open}
+          open={leftDrawerOpen}
           placement="start"
-          onSlAfterHide={() => setOpen(false)}
+          onSlAfterHide={() => setLeftDrawerOpen(false)}
           label="Componenten"
         >
           <Puck.Components />
@@ -54,11 +69,19 @@ export default function PageEditor({ data, onPublish }: Props) {
         <EditorHeader
           onPublish={onPublish}
           handleDrawerOpen={handleDrawerOpen}
+          isSaving={isSaving}
         />
 
-        <Puck.Preview />
+        <SlDrawer
+          open={rightDrawerOpen}
+          placement="end"
+          onSlAfterHide={() => setRightDrawerOpen(false)}
+          label="Velden"
+        >
+          <Puck.Fields />
+        </SlDrawer>
 
-        <EditorFooter />
+        <Puck.Preview />
       </div>
     </Puck>
   );
@@ -91,17 +114,16 @@ function MockShoelaceProvider({
 function EditorHeader({
   onPublish,
   handleDrawerOpen,
+  isSaving,
 }: {
   onPublish: Props['onPublish'];
-  handleDrawerOpen: () => void;
+  handleDrawerOpen: (orientation: 'left' | 'right') => void;
+  isSaving?: Props['isSaving'];
 }) {
   const { appState } = usePuck();
   const { SlButton, SlIconButton, SlIcon } = useContext(ShoelaceContext);
 
-  const [isPublishing, setIsPublishing] = useState(false);
-
   const publish = () => {
-    setIsPublishing(true);
     if (onPublish) {
       onPublish(appState.data);
     }
@@ -113,74 +135,32 @@ function EditorHeader({
         <div className="flex flex-row gap-2 justify-center items-center">
           <SlIconButton
             name="layout-sidebar-inset"
-            label="Toon zijbalk"
-            onClick={handleDrawerOpen}
+            label="Toon componenten"
+            onClick={() => handleDrawerOpen('left')}
             className="text-xl"
           />
-          <h1 className="text-xl font-bold">Editor</h1>
+          <h1 className="text-xl font-bold">Pagina bewerken</h1>
         </div>
 
-        <SlButton
-          variant="primary"
-          disabled={isPublishing}
-          loading={isPublishing}
-          onClick={publish}
-        >
-          <SlIcon name="cloud-upload" slot="prefix" />
-          Publiceren
-        </SlButton>
+        <div className="flex flex-row gap-2 justify-center items-center">
+          <SlButton
+            variant="primary"
+            disabled={isSaving}
+            loading={isSaving}
+            onClick={publish}
+          >
+            <SlIcon name="cloud-upload" slot="prefix" />
+            Publiceren
+          </SlButton>
+
+          <SlIconButton
+            name="layout-sidebar-inset-reverse"
+            label="Veld"
+            onClick={() => handleDrawerOpen('right')}
+            className="text-xl"
+          />
+        </div>
       </div>
     </header>
-  );
-}
-
-function EditorFooter() {
-  const {
-    appState: {
-      ui: { itemSelector },
-      data,
-    },
-  } = usePuck();
-  const { SlDrawer } = useContext(ShoelaceContext);
-  const [open, setOpen] = useState(false);
-  const [selectedBlockType, setSelectedBlockType] = useState('');
-
-  const ignoreBlocks = useMemo(() => {
-    return ['RichTextBlock'];
-  }, []);
-
-  useEffect(() => {
-    if (itemSelector) {
-      const { index: destinationIndex, zone: destinationZone } = itemSelector;
-
-      if (destinationZone) {
-        const item =
-          destinationZone !== 'default-zone' ?
-            data.zones?.[destinationZone]?.[destinationIndex]
-          : data.content[destinationIndex];
-        if (item) {
-          setSelectedBlockType(item.type);
-        }
-      }
-    }
-  }, [itemSelector, data]);
-
-  useEffect(() => {
-    if (selectedBlockType) {
-      if (!ignoreBlocks.includes(selectedBlockType)) {
-        setOpen(true);
-      }
-    }
-  }, [selectedBlockType, ignoreBlocks]);
-
-  return (
-    <SlDrawer
-      open={open}
-      placement="bottom"
-      onSlAfterHide={() => setOpen(false)}
-      label="Blok instellingen"
-    >
-      <Puck.Fields />
-    </SlDrawer>
   );
 }

--- a/app/components/PageMutationForm.stories.tsx
+++ b/app/components/PageMutationForm.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PageMutationForm from './PageMutationForm';
+
+export default {
+  title: 'Components/Page Mutation Form',
+  component: PageMutationForm,
+} satisfies Meta<typeof PageMutationForm>;
+
+type Story = StoryObj<typeof PageMutationForm>;
+
+export const Default: Story = {
+  args: {},
+};

--- a/app/components/PageMutationForm.stories.tsx
+++ b/app/components/PageMutationForm.stories.tsx
@@ -2,8 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import PageMutationForm from './PageMutationForm';
 
 export default {
-  title: 'Components/Page Mutation Form',
+  title: 'Forms/Page Mutation Form',
   component: PageMutationForm,
+  tags: ['components', 'content'],
 } satisfies Meta<typeof PageMutationForm>;
 
 type Story = StoryObj<typeof PageMutationForm>;

--- a/app/components/PageMutationForm.translations.ts
+++ b/app/components/PageMutationForm.translations.ts
@@ -1,0 +1,26 @@
+export const en = {
+  PageMutationForm: {
+    Title: {
+      New: 'New page',
+      Edit: 'Edit page',
+    },
+  },
+};
+
+export const nl = {
+  PageMutationForm: {
+    Title: {
+      New: 'Nieuwe pagina',
+      Edit: 'Bewerk pagina',
+    },
+  },
+};
+
+export const pap = {
+  PageMutationForm: {
+    Title: {
+      New: 'New page',
+      Edit: 'Edit page',
+    },
+  },
+};

--- a/app/components/PageMutationForm.tsx
+++ b/app/components/PageMutationForm.tsx
@@ -17,19 +17,14 @@ type OnPublishFn = ComponentProps<typeof Puck>['onPublish'];
 
 export default function PageMutationForm({ id = '', ...initialValues }: Props) {
   const { t } = useTranslation('PageMutationForm');
-  const { SlAlert } = useContext(ShoelaceContext);
   const fetcher = useFetcher<ErrorResponse<PageErrors, PageValidator>>();
-
-  const isSubmitting = fetcher.state !== 'idle';
-  const errors = fetcher.data?.errors;
-  const content = fetcher.data?.data?.content || initialValues?.content;
 
   const handleSubmit: OnPublishFn = (data) => {
     const formData = new FormData();
     formData.append('content.nl', JSON.stringify(data));
     formData.append('content.en', JSON.stringify(data));
     formData.append('content.pap', JSON.stringify(data));
-    formData.append('slug', 'test-slug');
+    // formData.append('slug', 'test-slug');
 
     console.log('formData', formData);
     fetcher.submit(formData, {
@@ -42,15 +37,13 @@ export default function PageMutationForm({ id = '', ...initialValues }: Props) {
     titleTranslationKey = 'Title.Edit';
   }
 
-  console.log('status', fetcher.state);
+  const isSubmitting = fetcher.state !== 'idle';
+  const content = fetcher.data?.data?.content || initialValues?.content;
+  const errors = fetcher.data?.errors;
 
   return (
     <>
-      <SlAlert variant="danger" open={!!errors}>
-        {Object.values(errors || []).map((error, index) => (
-          <div key={`error-${index}`}>{t(`Error.${error}`)}</div>
-        ))}
-      </SlAlert>
+      <FormErrors errors={errors} />
 
       <PageEditor
         onPublish={handleSubmit}
@@ -59,5 +52,49 @@ export default function PageMutationForm({ id = '', ...initialValues }: Props) {
         data={content?.nl}
       />
     </>
+  );
+}
+
+type FieldError = { field: string; message: string };
+
+function FormErrors({ errors }: { errors?: PageErrors }) {
+  const { SlAlert } = useContext(ShoelaceContext);
+  let messages: FieldError[] = [];
+
+  if (errors) {
+    messages = Object.keys(errors).reduce<FieldError[]>((acc, field) => {
+      let errorMessage = '';
+      const error = errors[field as keyof PageErrors];
+
+      if (!error) {
+        return acc;
+      }
+
+      if ('_errors' in error) {
+        errorMessage = error._errors.join(', ');
+      } else if (Array.isArray(error)) {
+        errorMessage = error.join(', ');
+      } else {
+        errorMessage = error;
+      }
+
+      if (!errorMessage) {
+        return acc;
+      }
+
+      return [...acc, { field, message: errorMessage }];
+    }, []);
+  }
+
+  return (
+    <SlAlert variant="danger" open={!!messages.length}>
+      <ul>
+        {messages.map(({ field, message }, index) => (
+          <li key={`error-${index}`}>
+            Fout bij veld {field}: {message}
+          </li>
+        ))}
+      </ul>
+    </SlAlert>
   );
 }

--- a/app/components/PageMutationForm.tsx
+++ b/app/components/PageMutationForm.tsx
@@ -8,12 +8,15 @@ import { ErrorResponse } from '~/types/Validations';
 import PageEditor from '~/components/PageEditor';
 import { useTranslation } from 'react-i18next';
 import { ShoelaceContext } from '~/components/shoelace';
+import { WatershedPageConfig } from '~/config/puck.config';
 
 type Props = DeepPartial<PageValidator> & {
   id?: string;
 };
 
-type OnPublishFn = ComponentProps<typeof Puck>['onPublish'];
+type OnPublishFn = ComponentProps<
+  typeof Puck<WatershedPageConfig>
+>['onPublish'];
 
 export default function PageMutationForm({ id = '', ...initialValues }: Props) {
   const { t } = useTranslation('PageMutationForm');
@@ -24,9 +27,8 @@ export default function PageMutationForm({ id = '', ...initialValues }: Props) {
     formData.append('content.nl', JSON.stringify(data));
     formData.append('content.en', JSON.stringify(data));
     formData.append('content.pap', JSON.stringify(data));
-    // formData.append('slug', 'test-slug');
+    formData.append('slug', data.root.props?.slug ?? '');
 
-    console.log('formData', formData);
     fetcher.submit(formData, {
       method: id ? 'PUT' : 'POST',
     });

--- a/app/components/PageMutationForm.tsx
+++ b/app/components/PageMutationForm.tsx
@@ -1,0 +1,63 @@
+import { useFetcher } from 'react-router';
+import { Puck } from '@measured/puck';
+import { ComponentProps, useContext } from 'react';
+// import { useTranslation } from 'react-i18next';
+import { DeepPartial } from '~/types/DeepPartial';
+import { PageErrors, PageValidator } from '~/validations/models/page';
+import { ErrorResponse } from '~/types/Validations';
+import PageEditor from '~/components/PageEditor';
+import { useTranslation } from 'react-i18next';
+import { ShoelaceContext } from '~/components/shoelace';
+
+type Props = DeepPartial<PageValidator> & {
+  id?: string;
+};
+
+type OnPublishFn = ComponentProps<typeof Puck>['onPublish'];
+
+export default function PageMutationForm({ id = '', ...initialValues }: Props) {
+  const { t } = useTranslation('PageMutationForm');
+  const { SlAlert } = useContext(ShoelaceContext);
+  const fetcher = useFetcher<ErrorResponse<PageErrors, PageValidator>>();
+
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = fetcher.data?.errors;
+  const content = fetcher.data?.data?.content || initialValues?.content;
+
+  const handleSubmit: OnPublishFn = (data) => {
+    const formData = new FormData();
+    formData.append('content.nl', JSON.stringify(data));
+    formData.append('content.en', JSON.stringify(data));
+    formData.append('content.pap', JSON.stringify(data));
+    formData.append('slug', 'test-slug');
+
+    console.log('formData', formData);
+    fetcher.submit(formData, {
+      method: id ? 'PUT' : 'POST',
+    });
+  };
+
+  let titleTranslationKey = 'Title.New';
+  if (id) {
+    titleTranslationKey = 'Title.Edit';
+  }
+
+  console.log('status', fetcher.state);
+
+  return (
+    <>
+      <SlAlert variant="danger" open={!!errors}>
+        {Object.values(errors || []).map((error, index) => (
+          <div key={`error-${index}`}>{t(`Error.${error}`)}</div>
+        ))}
+      </SlAlert>
+
+      <PageEditor
+        onPublish={handleSubmit}
+        isSaving={isSubmitting}
+        title={t(titleTranslationKey)}
+        data={content?.nl}
+      />
+    </>
+  );
+}

--- a/app/components/PageRenderer.stories.tsx
+++ b/app/components/PageRenderer.stories.tsx
@@ -2,8 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import PageRenderer from 'app/components/PageRenderer';
 
 export default {
-  title: 'Components/Page Renderer',
+  title: 'Templates/Page Renderer',
   component: PageRenderer,
+  tags: ['components', 'content'],
 } satisfies Meta<typeof PageRenderer>;
 
 type Story = StoryObj<typeof PageRenderer>;
@@ -11,7 +12,9 @@ type Story = StoryObj<typeof PageRenderer>;
 export const Default: Story = {
   args: {
     data: {
-      root: { props: { title: '' } },
+      root: {
+        props: { title: '', summary: '', meta: { title: '', description: '' } },
+      },
       zones: {},
       content: [
         {
@@ -20,7 +23,7 @@ export const Default: Story = {
             id: 'Heading-1694032984497',
             text: 'Welkom bij Watershed',
             align: 'center',
-            level: 1,
+            level: 2,
           },
         },
         {
@@ -43,7 +46,7 @@ export const Default: Story = {
           type: 'ButtonBlock',
           props: {
             id: 'Button-1234567890',
-            primary: 'primary',
+            variant: 'primary',
           },
         },
       ],

--- a/app/components/PageRenderer.stories.tsx
+++ b/app/components/PageRenderer.stories.tsx
@@ -13,7 +13,12 @@ export const Default: Story = {
   args: {
     data: {
       root: {
-        props: { title: '', summary: '', meta: { title: '', description: '' } },
+        props: {
+          title: '',
+          summary: '',
+          slug: '',
+          meta: { title: '', description: '' },
+        },
       },
       zones: {},
       content: [

--- a/app/components/PageRenderer.tsx
+++ b/app/components/PageRenderer.tsx
@@ -1,8 +1,8 @@
-import { Data, Render } from '@measured/puck';
-import { config } from '~/config/puck.config';
+import { Render } from '@measured/puck';
+import { config, WatershedPageData } from '~/config/puck.config';
 
 type Props = {
-  data: Partial<Data>;
+  data: Partial<WatershedPageData>;
 };
 
 export default function PageRenderer({ data }: Props) {

--- a/app/components/ProductSummary.stories.tsx
+++ b/app/components/ProductSummary.stories.tsx
@@ -3,9 +3,9 @@ import { faker } from '@faker-js/faker';
 import ProductSummary from './ProductSummary';
 
 export default {
-  title: 'Components/Product Summary',
+  title: 'Molecules/Product Summary',
   component: ProductSummary,
-  tags: ['news'],
+  tags: ['components', 'deprecated'],
 } satisfies Meta<typeof ProductSummary>;
 
 type Story = StoryObj<typeof ProductSummary>;

--- a/app/components/ProjectMutationForm.stories.tsx
+++ b/app/components/ProjectMutationForm.stories.tsx
@@ -6,8 +6,9 @@ import { validateProject } from '~/validations/models/project';
 import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 
 export default {
-  title: 'Components/Project Mutation Form',
+  title: 'Forms/Project Mutation Form',
   component: ProjectMutationForm,
+  tags: ['components', 'content'],
 } satisfies Meta<typeof ProjectMutationForm>;
 
 type Story = StoryObj<typeof ProjectMutationForm>;

--- a/app/components/ProjectSummary.stories.tsx
+++ b/app/components/ProjectSummary.stories.tsx
@@ -3,9 +3,9 @@ import { fakerEN, fakerNL, fakerEO } from '@faker-js/faker';
 import ProjectSummary from './ProjectSummary';
 
 export default {
-  title: 'Components/Project Summary',
+  title: 'Molecules/Project Summary',
   component: ProjectSummary,
-  tags: ['news'],
+  tags: ['components', 'content'],
   decorators: [(Story) => <div className="w-1/3">{Story()}</div>],
 } satisfies Meta<typeof ProjectSummary>;
 

--- a/app/components/RichTextEditor.stories.tsx
+++ b/app/components/RichTextEditor.stories.tsx
@@ -2,8 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import RichTextEditor from 'app/components/RichTextEditor';
 
 export default {
-  title: 'Components/Rich Text Editor',
+  title: 'Molecules/Rich Text Editor',
   component: RichTextEditor,
+  tags: ['components', 'content', 'input'],
 } satisfies Meta<typeof RichTextEditor>;
 
 type Story = StoryObj<typeof RichTextEditor>;

--- a/app/components/SubMenu.stories.tsx
+++ b/app/components/SubMenu.stories.tsx
@@ -3,8 +3,9 @@ import SubMenu from './SubMenu';
 import SubMenuItem from '~/components/SubMenuItem';
 
 export default {
-  title: 'Components/Sub Menu',
+  title: 'Molecules/Sub Menu',
   component: SubMenu,
+  tags: ['components', 'navigation'],
 } satisfies Meta<typeof SubMenu>;
 
 type Story = StoryObj<typeof SubMenu>;

--- a/app/components/Tags.stories.tsx
+++ b/app/components/Tags.stories.tsx
@@ -3,8 +3,9 @@ import { faker } from '@faker-js/faker';
 import Tags from './Tags';
 
 export default {
-  title: 'Components/Tags',
+  title: 'Atoms/Tags',
   component: Tags,
+  tags: ['components', 'navigation'],
 } satisfies Meta<typeof Tags>;
 
 type Story = StoryObj<typeof Tags>;

--- a/app/components/YearSelector.stories.tsx
+++ b/app/components/YearSelector.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import YearSelector from './YearSelector';
 
 export default {
-  title: 'Components/Year Selector',
+  title: 'Molecules/Year Selector',
   component: YearSelector,
-  tags: ['news'],
+  tags: ['components', 'shoelace'],
 } satisfies Meta<typeof YearSelector>;
 
 type Story = StoryObj<typeof YearSelector>;

--- a/app/config/blocks/HeadingBlock.tsx
+++ b/app/config/blocks/HeadingBlock.tsx
@@ -10,14 +10,13 @@ export type Props = {
   padding?: string;
 };
 
+// Since the page title is always level 1, we start at level 2.
 const levelOptions = [
   { label: '', value: '' },
-  { label: '1', value: 1 },
-  { label: '2', value: 2 },
-  { label: '3', value: 3 },
-  { label: '4', value: 4 },
-  { label: '5', value: 5 },
-  { label: '6', value: 6 },
+  { label: '1', value: 2 },
+  { label: '2', value: 3 },
+  { label: '3', value: 4 },
+  { label: '4', value: 5 },
 ];
 
 export const HeadingBlock: ComponentConfig<Props> = {

--- a/app/config/puck.config.tsx
+++ b/app/config/puck.config.tsx
@@ -1,4 +1,4 @@
-import type { Config } from '@measured/puck';
+import type { Config, Data } from '@measured/puck';
 import {
   HeadingBlock,
   Props as HeadingBlockProps,
@@ -26,6 +26,8 @@ type RootProps = {
     description: string;
   };
 };
+
+export type WatershedPageData = Data<Props, RootProps>;
 
 export const config: Config<Props, RootProps> = {
   categories: {
@@ -76,7 +78,9 @@ export const config: Config<Props, RootProps> = {
     render({ children, title }) {
       return (
         <div className="flex flex-col gap-4">
-          <Heading level={1}>{title}</Heading>
+          {title ?
+            <Heading level={1}>{title}</Heading>
+          : null}
           {children}
         </div>
       );

--- a/app/config/puck.config.tsx
+++ b/app/config/puck.config.tsx
@@ -9,6 +9,7 @@ import {
 } from '~/config/blocks/RichTextBlock';
 import { ButtonBlock, ButtonBlockProps } from '~/config/blocks/ButtonBlock';
 import { GridBlock, GribBlockProps } from '~/config/blocks/GridBlock';
+import Heading from '~/components/Heading';
 
 type Props = {
   HeadingBlock: HeadingBlockProps;
@@ -17,7 +18,16 @@ type Props = {
   GridBlock: GribBlockProps;
 };
 
-export const config: Config<Props> = {
+type RootProps = {
+  title: string;
+  summary: string;
+  meta: {
+    title: string;
+    description: string;
+  };
+};
+
+export const config: Config<Props, RootProps> = {
   categories: {
     typography: {
       title: 'Typography',
@@ -37,6 +47,40 @@ export const config: Config<Props> = {
     RichTextBlock,
     ButtonBlock,
     GridBlock,
+  },
+  root: {
+    fields: {
+      title: {
+        label: 'Pagina titel',
+        type: 'text',
+      },
+      summary: {
+        label: 'Pagina omschrijving',
+        type: 'textarea',
+      },
+      meta: {
+        type: 'object',
+        label: 'SEO',
+        objectFields: {
+          title: {
+            label: 'Titel',
+            type: 'text',
+          },
+          description: {
+            label: 'Beschrijving',
+            type: 'textarea',
+          },
+        },
+      },
+    },
+    render({ children, title }) {
+      return (
+        <div className="flex flex-col gap-4">
+          <Heading level={1}>{title}</Heading>
+          {children}
+        </div>
+      );
+    },
   },
 };
 

--- a/app/config/puck.config.tsx
+++ b/app/config/puck.config.tsx
@@ -21,6 +21,7 @@ type Props = {
 type RootProps = {
   title: string;
   summary: string;
+  slug: string;
   meta: {
     title: string;
     description: string;
@@ -28,6 +29,7 @@ type RootProps = {
 };
 
 export type WatershedPageData = Data<Props, RootProps>;
+export type WatershedPageConfig = Config<Props, RootProps>;
 
 export const config: Config<Props, RootProps> = {
   categories: {
@@ -59,6 +61,10 @@ export const config: Config<Props, RootProps> = {
       summary: {
         label: 'Pagina omschrijving',
         type: 'textarea',
+      },
+      slug: {
+        label: 'Slug',
+        type: 'text',
       },
       meta: {
         type: 'object',

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -28,6 +28,8 @@ import { en as LocaleSelectorTranslations } from '~/components/LocaleSelector.tr
 export const { LocaleSelector } = LocaleSelectorTranslations;
 import { en as LocalisedInputTranslations } from '~/components/LocalisedInput.translations';
 export const { LocalisedInput } = LocalisedInputTranslations;
+import { en as PageMutationFormTranslations } from '~/components/PageMutationForm.translations';
+export const { PageMutationForm } = PageMutationFormTranslations;
 
 export const common = {
   title: 'Hello World!',
@@ -152,15 +154,21 @@ export const ContentTypes = {
   evenementen_other: 'Events',
   projecten_one: 'Project',
   projecten_other: 'Projects',
+  paginas_one: 'Page',
+  paginas_other: 'Pages',
 };
 
 export const ContentOverviewRoute = {
   ...ContentTypes,
   Meta: {
-    Title: 'Admin - $t({{content}}, lowercase) | Stichting Watershed',
+    Title:
+      'Admin - $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
   },
-  Title: '$t({{content}}, capitalize)',
-  NewButtonCaption: 'New $t({{content}}, lowercase)',
+  Title: '$t(ContentTypes:{{content}}, capitalize)',
+  NewButtonCaption: {
+    Common: 'New $t(ContentTypes:{{content}}, lowercase)',
+    Neuter: 'New $t(ContentTypes:{{content}}, lowercase)',
+  },
 };
 
 export const NewContentRoute = {
@@ -199,6 +207,21 @@ export const ProjectIndexRoute = {
 };
 
 export const ProjectDetailRoute = {
+  Meta: {
+    Title: '{{title}} | Stichting Watershed',
+    description: '{{description}}',
+  },
+};
+
+export const PageIndexRoute = {
+  Title: 'Pages',
+  Meta: {
+    Title: 'Pages | Stichting Watershed',
+    Description: 'Our pages',
+  },
+};
+
+export const PageDetailRoute = {
   Meta: {
     Title: '{{title}} | Stichting Watershed',
     description: '{{description}}',

--- a/app/locales/nl.ts
+++ b/app/locales/nl.ts
@@ -28,6 +28,8 @@ import { nl as LocaleSelectorTranslations } from '~/components/LocaleSelector.tr
 export const { LocaleSelector } = LocaleSelectorTranslations;
 import { nl as LocalisedInputTranslations } from '~/components/LocalisedInput.translations';
 export const { LocalisedInput } = LocalisedInputTranslations;
+import { nl as PageMutationFormTranslations } from '~/components/PageMutationForm.translations';
+export const { PageMutationForm } = PageMutationFormTranslations;
 
 export const common = {
   title: 'Hallo Wereld!',
@@ -153,15 +155,21 @@ export const ContentTypes = {
   evenementen_other: 'Evenementen',
   projecten_one: 'Project',
   projecten_other: 'Projecten',
+  paginas_one: 'Pagina',
+  paginas_other: "Pagina's",
 };
 
 export const ContentOverviewRoute = {
   ...ContentTypes,
   Meta: {
-    Title: 'Beheer - $t({{content}}, lowercase) | Stichting Watershed',
+    Title:
+      'Beheer - $t(ContentTypes:{{content}}, lowercase) | Stichting Watershed',
   },
-  Title: '$t({{content}}, capitalize)',
-  NewButtonCaption: 'Nieuw $t({{content}}, {"count": {{count}} })',
+  Title: '$t(ContentTypes:{{content}}, capitalize)',
+  NewButtonCaption: {
+    Common: 'Nieuwe $t(ContentTypes:{{content}}, {"count": {{count}} })',
+    Neuter: 'Nieuw $t(ContentTypes:{{content}}, {"count": {{count}} })',
+  },
 };
 
 export const NewContentRoute = {
@@ -202,6 +210,21 @@ export const ProjectIndexRoute = {
 };
 
 export const ProjectDetailRoute = {
+  Meta: {
+    Title: '{{title}} | Stichting Watershed',
+    description: '{{description}}',
+  },
+};
+
+export const PageIndexRoute = {
+  Title: "Pagina's",
+  Meta: {
+    Title: "Pagina's | Stichting Watershed",
+    Description: "Bekijk onze pagina's",
+  },
+};
+
+export const PageDetailRoute = {
   Meta: {
     Title: '{{title}} | Stichting Watershed',
     description: '{{description}}',

--- a/app/models/pages.server.ts
+++ b/app/models/pages.server.ts
@@ -1,6 +1,8 @@
 import { Page } from '@prisma/client';
 import { prisma } from '~/.server/db';
 import { type ContentTableItem } from '~/components/ContentTable';
+import { PageValidator } from '~/validations/models/page';
+import { SupportedLanguages } from '~/config/i18n';
 
 export function getPages() {
   return prisma.page.findMany({
@@ -18,10 +20,19 @@ export function getPageBySlug(slug: string) {
   });
 }
 
-export function convertPagesToTableData(pages: Page[]): ContentTableItem[] {
+export function savePage(page: PageValidator) {
+  return prisma.page.create({
+    data: page,
+  });
+}
+
+export function convertPagesToTableData(
+  pages: Page[],
+  locale: SupportedLanguages,
+): ContentTableItem[] {
   return pages.map((page) => ({
     id: page.id,
-    title: { value: page.title, isName: true },
+    title: { value: page.content[locale].root.props.title, isName: true },
     slug: page.slug,
     createdAt: page.createdAt,
   }));

--- a/app/models/pages.server.ts
+++ b/app/models/pages.server.ts
@@ -50,6 +50,7 @@ export function convertPagesToTableData(
   return pages.map((page) => ({
     id: page.id,
     title: { value: page.content[locale].root.props.title, isName: true },
+    description: page.content[locale].root.props.summary,
     slug: page.slug,
     createdAt: page.createdAt,
   }));

--- a/app/models/pages.server.ts
+++ b/app/models/pages.server.ts
@@ -12,6 +12,14 @@ export function getPages() {
   });
 }
 
+export function getPage(id: string) {
+  return prisma.page.findFirstOrThrow({
+    where: {
+      id,
+    },
+  });
+}
+
 export function getPageBySlug(slug: string) {
   return prisma.page.findFirstOrThrow({
     where: {
@@ -22,6 +30,15 @@ export function getPageBySlug(slug: string) {
 
 export function savePage(page: PageValidator) {
   return prisma.page.create({
+    data: page,
+  });
+}
+
+export function updatePage(id: string, page: PageValidator) {
+  return prisma.page.update({
+    where: {
+      id,
+    },
     data: page,
   });
 }

--- a/app/models/pages.server.ts
+++ b/app/models/pages.server.ts
@@ -1,8 +1,12 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+// TODO: Fix the pageValidator type so that we can check the save and update functions
 import { Page } from '@prisma/client';
 import { prisma } from '~/.server/db';
 import { type ContentTableItem } from '~/components/ContentTable';
 import { PageValidator } from '~/validations/models/page';
 import { SupportedLanguages } from '~/config/i18n';
+import { WatershedPageData } from '~/config/puck.config';
 
 export function getPages() {
   return prisma.page.findMany({
@@ -49,8 +53,13 @@ export function convertPagesToTableData(
 ): ContentTableItem[] {
   return pages.map((page) => ({
     id: page.id,
-    title: { value: page.content[locale].root.props.title, isName: true },
-    description: page.content[locale].root.props.summary,
+    title: {
+      value:
+        (page.content[locale] as WatershedPageData).root.props?.title ?? '',
+      isName: true,
+    },
+    description:
+      (page.content[locale] as WatershedPageData).root.props?.summary ?? '',
     slug: page.slug,
     createdAt: page.createdAt,
   }));

--- a/app/routes/($lang)/$/_pages.tsx
+++ b/app/routes/($lang)/$/_pages.tsx
@@ -5,6 +5,7 @@ import { data, useLoaderData } from 'react-router';
 import PageRenderer from '~/components/PageRenderer';
 import { Prisma } from '@prisma/client';
 import { SupportedLanguages } from '~/config/i18n';
+import { WatershedPageData } from '~/config/puck.config';
 
 export async function loader({ params }: Route.LoaderArgs) {
   const { locale, slug } = parseParamsToSlug(params);
@@ -12,12 +13,16 @@ export async function loader({ params }: Route.LoaderArgs) {
   try {
     const pageData = await getPageBySlug(slug || 'home');
 
+    const data = pageData.content[
+      locale as SupportedLanguages
+    ] as WatershedPageData;
+
     return {
-      title: pageData.title[locale as SupportedLanguages],
-      data: pageData.content[locale as SupportedLanguages],
+      title: data.root.title,
+      data: data,
       meta: {
-        title: pageData.meta.title[locale as SupportedLanguages],
-        description: pageData.meta.description[locale as SupportedLanguages],
+        title: data.root.meta?.title,
+        description: data.root.meta?.description,
       },
     };
   } catch (error) {

--- a/app/routes/($lang)/account/AccountMenu.stories.tsx
+++ b/app/routes/($lang)/account/AccountMenu.stories.tsx
@@ -3,7 +3,7 @@ import AccountMenu from './AccountMenu';
 import { User } from '~/models/user.server';
 
 export default {
-  title: 'Components/Account Menu',
+  title: 'Molecules/Account Menu',
   component: AccountMenu,
   decorators: [
     (Story) => (
@@ -12,6 +12,7 @@ export default {
       </div>
     ),
   ],
+  tags: ['route-components', 'navigation'],
 } satisfies Meta<typeof AccountMenu>;
 
 type Story = StoryObj<typeof AccountMenu>;

--- a/app/routes/($lang)/account/AccountMenu.translations.ts
+++ b/app/routes/($lang)/account/AccountMenu.translations.ts
@@ -10,6 +10,7 @@ export const en = {
       Title: 'Administration',
       Events: 'Events',
       Projects: 'Events',
+      Pages: 'Pages',
     },
   },
 };
@@ -26,6 +27,7 @@ export const nl = {
       Title: 'Administratie',
       Events: 'Evenementen',
       Projects: 'Projecten',
+      Pages: "Pagina's",
     },
   },
 };
@@ -42,6 +44,7 @@ export const pap = {
       Title: 'Admin',
       Events: 'Events',
       Projects: 'Events',
+      Pages: 'Pages',
     },
   },
 };

--- a/app/routes/($lang)/account/AccountMenu.translations.ts
+++ b/app/routes/($lang)/account/AccountMenu.translations.ts
@@ -3,7 +3,7 @@ export const en = {
     Greeting: 'Hello {{name}}',
     AccountMenuLinks: {
       Title: 'My account',
-      Dashboard: 'Dashboard',
+      Dashboard: 'Profile',
       Settings: 'Settings',
     },
     AdminMenuLinks: {
@@ -20,11 +20,11 @@ export const nl = {
     Greeting: 'Hallo {{name}}',
     AccountMenuLinks: {
       Title: 'Mijn account',
-      Dashboard: 'Dashboard',
+      Dashboard: 'Profiel',
       Settings: 'Instellingen',
     },
     AdminMenuLinks: {
-      Title: 'Administratie',
+      Title: 'Beheer',
       Events: 'Evenementen',
       Projects: 'Projecten',
       Pages: "Pagina's",
@@ -37,7 +37,7 @@ export const pap = {
     Greeting: 'Bon dia {{name}}',
     AccountMenuLinks: {
       Title: 'Account',
-      Dashboard: 'Dashboard',
+      Dashboard: 'Profile',
       Settings: 'Settings',
     },
     AdminMenuLinks: {

--- a/app/routes/($lang)/account/AccountMenu.tsx
+++ b/app/routes/($lang)/account/AccountMenu.tsx
@@ -26,6 +26,9 @@ export default function AccountMenu({ user }: Props) {
       </SubMenu>
 
       <SubMenu title={t('AdminMenuLinks.Title')} to="/beheer">
+        <SubMenuItem to="/beheer/paginas" icon="file-earmark">
+          {t('AdminMenuLinks.Pages')}
+        </SubMenuItem>
         <SubMenuItem to="/beheer/evenementen" icon="calendar2-event">
           {t('AdminMenuLinks.Events')}
         </SubMenuItem>

--- a/app/routes/($lang)/beheer/$content/_index/ConfirmDeleteDialog.stories.tsx
+++ b/app/routes/($lang)/beheer/$content/_index/ConfirmDeleteDialog.stories.tsx
@@ -6,9 +6,10 @@ import { reactRouterParameters } from 'storybook-addon-remix-react-router';
 import { useFetcher } from 'react-router';
 
 export default {
-  title: 'Components/Confirm Deletion dialog',
+  title: 'Molecules/Confirm Deletion dialog',
   component: ConfirmDeleteDialog,
   parameters: { actions: { argTypesRegex: '^on.*' } },
+  tags: ['route-components', 'shoelace', 'content'],
 } satisfies Meta<typeof ConfirmDeleteDialog>;
 
 type Story = StoryObj<typeof ConfirmDeleteDialog>;

--- a/app/routes/($lang)/beheer/$content/_index/DeletionNotification.stories.tsx
+++ b/app/routes/($lang)/beheer/$content/_index/DeletionNotification.stories.tsx
@@ -5,8 +5,9 @@ import { ShoelaceContext } from '~/components/shoelace';
 import { SlAlert } from '@shoelace-style/shoelace';
 
 export default {
-  title: 'Components/Deletion notification',
+  title: 'Molecules/Deletion notification',
   component: DeletionNotification,
+  tags: ['route-components', 'content', 'shoelace'],
 } satisfies Meta<typeof DeletionNotification>;
 
 type Story = StoryObj<typeof DeletionNotification>;

--- a/app/routes/($lang)/beheer/$content/_index/_overview.tsx
+++ b/app/routes/($lang)/beheer/$content/_index/_overview.tsx
@@ -16,9 +16,11 @@ import DeletionNotification from './DeletionNotification';
 import i18nServer from '~/modules/i18n.server';
 import { ShoelaceContext } from '~/components/shoelace';
 import { convertPagesToTableData, getPages } from '~/models/pages.server';
+import { SupportedLanguages } from '~/config/i18n';
 
 export const handle = {
   i18n: [
+    'ContentTypes',
     'ContentOverviewRoute',
     'ContentTable',
     'ConfirmDeleteDialog',
@@ -29,13 +31,14 @@ export const handle = {
 export async function loader({ params, request }: Route.LoaderArgs) {
   const content = params.content as ContentURLParams;
   const t = await i18nServer.getFixedT(request, 'ContentOverviewRoute');
+  const locale = (await i18nServer.getLocale(request)) as SupportedLanguages;
 
   let data: ContentTableItem[] = [];
 
   switch (content) {
     case 'paginas': {
       const pages = await getPages();
-      data = convertPagesToTableData(pages);
+      data = convertPagesToTableData(pages, locale);
       break;
     }
 
@@ -68,7 +71,9 @@ export const meta: Route.MetaFunction = ({ data }) => {
   ];
 };
 
-export default function ContentOverviewRoute({ params }: Route.ComponentProps) {
+export default function AdminContentOverviewRoute({
+  params,
+}: Route.ComponentProps) {
   const content = params.content as ContentURLParams;
   const { SlButton, SlIcon } = useContext(ShoelaceContext);
   const { data } = useLoaderData<typeof loader>();
@@ -112,13 +117,18 @@ export default function ContentOverviewRoute({ params }: Route.ComponentProps) {
 
   const isDeleting = fetcher.state !== 'idle';
 
+  let newButtonTranslationKey = 'NewButtonCaption.Neuter';
+  if (content === 'paginas') {
+    newButtonTranslationKey = 'NewButtonCaption.Common';
+  }
+
   return (
     <div className="space-y-4">
       <div className="flex flex-row justify-between items-center">
-        <Heading level={1}>{t('Title', { content })}</Heading>
+        <Heading level={1}>{t('Title', { content, count: 2 })}</Heading>
         <SlButton href={`/beheer/${content}/nieuw`} variant="primary">
           <SlIcon slot="prefix" name="plus-circle-dotted"></SlIcon>
-          {t('NewButtonCaption', { content, count: 1 })}
+          {t(newButtonTranslationKey, { content, count: 1 })}
         </SlButton>
       </div>
 

--- a/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx
+++ b/app/routes/($lang)/beheer/$content/bewerken/$id/_bewerken.tsx
@@ -12,6 +12,9 @@ import {
   ProjectValidator,
   validateProject,
 } from '~/validations/models/project';
+import { getPage, updatePage } from '~/models/pages.server';
+import { PageValidator, validatePage } from '~/validations/models/page';
+import PageMutationForm from '~/components/PageMutationForm';
 
 export const handle = {
   i18n: 'EditContentRoute',
@@ -37,6 +40,9 @@ export async function loader({ params, request }: Route.LoaderArgs) {
 
   let payload;
   switch (content) {
+    case 'paginas':
+      payload = await getPage(id);
+      break;
     case 'evenementen':
       payload = await getEvent(id);
       break;
@@ -57,6 +63,9 @@ export async function action({ params, request }: Route.ActionArgs) {
   let validatorFn;
 
   switch (content) {
+    case 'paginas':
+      validatorFn = validatePage;
+      break;
     case 'evenementen':
       validatorFn = validateEvent;
       break;
@@ -73,6 +82,9 @@ export async function action({ params, request }: Route.ActionArgs) {
 
     if (result.success) {
       switch (content) {
+        case 'paginas':
+          await updatePage(id, result.data as PageValidator);
+          break;
         case 'evenementen':
           await updateEvent(id, result.data as EventValidator);
           break;
@@ -114,6 +126,8 @@ export default function AdminEditContentRoute({
 
   function getForm() {
     switch (type) {
+      case 'paginas':
+        return <PageMutationForm {...payload} />;
       case 'projecten':
         return <ProjectMutationForm {...payload} />;
       case 'evenementen':

--- a/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
+++ b/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
@@ -12,8 +12,9 @@ import { saveEvent } from '~/models/events.server';
 import { saveProject } from '~/models/projects.server';
 import ProjectMutationForm from '~/components/ProjectMutationForm';
 import EventMutationForm from '~/components/EventMutationForm';
-import { validatePage } from '~/validations/models/page';
+import { PageValidator, validatePage } from '~/validations/models/page';
 import PageMutationForm from '~/components/PageMutationForm';
+import { savePage } from '~/models/pages.server';
 
 export const handle = {
   i18n: [
@@ -21,7 +22,6 @@ export const handle = {
     'ProjectMutationForm',
     'EventMutationForm',
     'PageMutationForm',
-    'PageEditor',
   ],
 };
 
@@ -59,6 +59,9 @@ export async function action({ params, request }: Route.ActionArgs) {
 
     if (result.success) {
       switch (content) {
+        case 'paginas':
+          await savePage(result.data as PageValidator);
+          break;
         case 'projecten':
           await saveProject(result.data as ProjectValidator);
           break;
@@ -102,5 +105,5 @@ export default function AdminNewContentRoute({ params }: Route.ComponentProps) {
     }
   }
 
-  return <div className="w-full">{getForm()}</div>;
+  return <div className="w-full min-h-screen">{getForm()}</div>;
 }

--- a/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
+++ b/app/routes/($lang)/beheer/$content/nieuw/_nieuw.tsx
@@ -12,9 +12,17 @@ import { saveEvent } from '~/models/events.server';
 import { saveProject } from '~/models/projects.server';
 import ProjectMutationForm from '~/components/ProjectMutationForm';
 import EventMutationForm from '~/components/EventMutationForm';
+import { validatePage } from '~/validations/models/page';
+import PageMutationForm from '~/components/PageMutationForm';
 
 export const handle = {
-  i18n: ['NewContentRoute', 'ProjectMutationForm', 'EventMutationForm'],
+  i18n: [
+    'NewContentRoute',
+    'ProjectMutationForm',
+    'EventMutationForm',
+    'PageMutationForm',
+    'PageEditor',
+  ],
 };
 
 export async function loader({ params, request }: Route.LoaderArgs) {
@@ -33,6 +41,9 @@ export async function action({ params, request }: Route.ActionArgs) {
   let validatorFn;
 
   switch (content) {
+    case 'paginas':
+      validatorFn = validatePage;
+      break;
     case 'projecten':
       validatorFn = validateProject;
       break;
@@ -82,6 +93,8 @@ export default function AdminNewContentRoute({ params }: Route.ComponentProps) {
 
   function getForm() {
     switch (type) {
+      case 'paginas':
+        return <PageMutationForm />;
       case 'projecten':
         return <ProjectMutationForm />;
       case 'evenementen':

--- a/app/routes/($lang)/beheer/AdminMenu.stories.tsx
+++ b/app/routes/($lang)/beheer/AdminMenu.stories.tsx
@@ -2,8 +2,9 @@ import type { Meta, StoryObj } from '@storybook/react';
 import AdminMenu from './AdminMenu';
 
 export default {
-  title: 'Components/Admin Menu',
+  title: 'Molecules/Admin Menu',
   component: AdminMenu,
+  tags: ['route-components', 'navigation'],
 } satisfies Meta<typeof AdminMenu>;
 
 type Story = StoryObj<typeof AdminMenu>;

--- a/app/routes/($lang)/inloggen/LoginFormComponent.stories.tsx
+++ b/app/routes/($lang)/inloggen/LoginFormComponent.stories.tsx
@@ -15,6 +15,7 @@ export default {
   parameters: {
     layout: 'padded',
   },
+  tags: ['route-components', 'authentication'],
 } satisfies Meta<typeof LoginFormComponent>;
 
 type Story = StoryObj<typeof LoginFormComponent>;

--- a/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordConfirmation.stories.ts
+++ b/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordConfirmation.stories.ts
@@ -2,8 +2,9 @@ import { Meta, StoryObj } from '@storybook/react';
 import ForgetPasswordConfirmation from './ForgetPasswordConfirmation';
 
 export default {
-  title: 'Components/Forget password confirmation',
+  title: 'Templates/Forget password confirmation',
   component: ForgetPasswordConfirmation,
+  tags: ['route-components', 'authentication'],
 } satisfies Meta<typeof ForgetPasswordConfirmation>;
 
 type Story = StoryObj<typeof ForgetPasswordConfirmation>;

--- a/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.stories.tsx
+++ b/app/routes/($lang)/wachtwoord-vergeten/ForgetPasswordFormComponent.stories.tsx
@@ -11,6 +11,7 @@ export default {
       </div>
     ),
   ],
+  tags: ['route-components', 'authentication'],
 } as Meta<typeof ForgetPasswordFormComponent>;
 
 type Story = StoryObj<typeof ForgetPasswordFormComponent>;

--- a/app/routes/_index/_home.tsx
+++ b/app/routes/_index/_home.tsx
@@ -4,18 +4,22 @@ import { data, useLoaderData } from 'react-router';
 import PageRenderer from '~/components/PageRenderer';
 import { Prisma } from '@prisma/client';
 import { fallbackLanguage, SupportedLanguages } from '~/config/i18n';
+import { WatershedPageData } from '~/config/puck.config';
 
 export async function loader() {
   try {
     const pageData = await getPageBySlug('home');
 
+    const data = pageData.content[
+      fallbackLanguage as SupportedLanguages
+    ] as WatershedPageData;
+
     return {
-      title: pageData.title[fallbackLanguage as SupportedLanguages],
-      data: pageData.content[fallbackLanguage as SupportedLanguages],
+      title: data.root.title,
+      data,
       meta: {
-        title: pageData.meta.title[fallbackLanguage as SupportedLanguages],
-        description:
-          pageData.meta.description[fallbackLanguage as SupportedLanguages],
+        title: data.root.meta?.title,
+        description: data.root.meta?.description,
       },
     };
   } catch (error) {

--- a/app/validations/models/page.test.ts
+++ b/app/validations/models/page.test.ts
@@ -1,0 +1,33 @@
+import { test, expect } from 'vitest';
+import { pageValidator } from './page';
+
+test('Validating the page', () => {
+  const validData = {
+    content: {
+      en: {},
+      nl: {},
+      pap: {},
+    },
+    slug: 'valid-slug',
+  };
+
+  const invalidData = {
+    content: {
+      en: {},
+      nl: {},
+      pap: {},
+    },
+    slug: '',
+  };
+
+  const validResult = pageValidator.safeParse(validData);
+  const invalidResult = pageValidator.safeParse(invalidData);
+
+  expect(validResult.success).toBe(true);
+  expect(invalidResult.success).toBe(false);
+  // expect(invalidResult.error.format()).toEqual({
+  //   slug: {
+  //     _errors: ['Invalid string'],
+  //   },
+  // });
+});

--- a/app/validations/models/page.ts
+++ b/app/validations/models/page.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+import { Data, ErrorValidation, SuccessValidation } from '~/types/Validations';
+import { transformFormData } from '~/utils/content';
+
+const localisedStringValidations = z.object({
+  nl: z.string().min(1),
+  en: z.string().min(1),
+  pap: z.string().min(1),
+});
+
+export const pageValidator = z.object({
+  title: localisedStringValidations,
+  description: localisedStringValidations,
+  content: localisedStringValidations,
+  slug: z.string().min(1),
+  // meta: z.array(
+  //   z.object({
+  //     name: localisedStringValidations,
+  //     description: localisedStringValidations,
+  //   }),
+  // ),
+});
+
+export type PageValidator = z.infer<typeof pageValidator>;
+export type PageErrors = z.inferFormattedError<typeof pageValidator>;
+
+export async function validatePage(
+  request: Request,
+): Promise<SuccessValidation<PageValidator> | ErrorValidation<PageValidator>> {
+  const clonedRequest = request.clone();
+  const formData = await clonedRequest.formData();
+  const transformedData = transformFormData(formData);
+
+  const result = pageValidator.safeParse(transformedData);
+
+  if (result.success) {
+    return result as SuccessValidation<PageValidator>;
+  }
+
+  return {
+    success: false,
+    errors: result.error.format(),
+    data: transformedData as Data<PageValidator>,
+  } as ErrorValidation<PageValidator>;
+}

--- a/app/validations/models/page.ts
+++ b/app/validations/models/page.ts
@@ -2,23 +2,15 @@ import { z } from 'zod';
 import { Data, ErrorValidation, SuccessValidation } from '~/types/Validations';
 import { transformFormData } from '~/utils/content';
 
-const localisedStringValidations = z.object({
-  nl: z.string().min(1),
-  en: z.string().min(1),
-  pap: z.string().min(1),
-});
+const dataSchema = z.any();
 
 export const pageValidator = z.object({
-  title: localisedStringValidations,
-  description: localisedStringValidations,
-  content: localisedStringValidations,
+  content: z.object({
+    en: dataSchema,
+    nl: dataSchema,
+    pap: dataSchema,
+  }),
   slug: z.string().min(1),
-  // meta: z.array(
-  //   z.object({
-  //     name: localisedStringValidations,
-  //     description: localisedStringValidations,
-  //   }),
-  // ),
 });
 
 export type PageValidator = z.infer<typeof pageValidator>;
@@ -34,7 +26,17 @@ export async function validatePage(
   const result = pageValidator.safeParse(transformedData);
 
   if (result.success) {
-    return result as SuccessValidation<PageValidator>;
+    return {
+      ...result,
+      data: {
+        ...result.data,
+        content: {
+          en: JSON.parse(result.data.content.en),
+          nl: JSON.parse(result.data.content.nl),
+          pap: JSON.parse(result.data.content.pap),
+        },
+      },
+    } as SuccessValidation<PageValidator>;
   }
 
   return {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "db:seed": "prisma db seed",
     "db:studio": "prisma studio --browser none",
     "db:deploy:dev": "npm run db:migrate:reset -- --force",
+    "db:diff": "./scripts/diff-db-staging.zsh",
     "playwright:install": "playwright install --with-deps",
     "storybook:serve": "http-server storybook-static -p 6006 --silent",
     "storybook:wait-until-reachable": "wait-on tcp:6006",

--- a/prisma/migrations/20250411091533_dropped_meta_info_for_puck_root_data_and_changed_slug_to_unique/migration.sql
+++ b/prisma/migrations/20250411091533_dropped_meta_info_for_puck_root_data_and_changed_slug_to_unique/migration.sql
@@ -1,0 +1,16 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `meta` on the `Page` table. All the data in the column will be lost.
+  - You are about to drop the column `summary` on the `Page` table. All the data in the column will be lost.
+  - You are about to drop the column `title` on the `Page` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[slug]` on the table `Page` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "Page" DROP COLUMN "meta",
+DROP COLUMN "summary",
+DROP COLUMN "title";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Page_slug_key" ON "Page"("slug");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -96,17 +96,8 @@ model Event {
 model Page {
   id String @id @default(cuid())
 
-  /// [Localised]
-  title Json
-
-  /// [Localised]
-  summary Json
-
   /// [LocalisedContent]
   content Json
-
-  /// [LocalisedPageMeta]
-  meta Json
 
   slug String
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -99,7 +99,7 @@ model Page {
   /// [LocalisedContent]
   content Json
 
-  slug String
+  slug String @unique
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/prisma/seed/_content.ts
+++ b/prisma/seed/_content.ts
@@ -60,85 +60,19 @@ const createEvents = (client: PrismaClient) => {
 const createPages = (client: PrismaClient) => {
   const pages = [
     {
-      title: {
-        en: 'Home',
-        nl: 'Home',
-        pap: 'Kas',
-      },
-      summary: {
-        en: 'Welcome to our website',
-        nl: 'Welkom op onze website',
-        pap: 'Bon biní na nos wèpsait',
-      },
       content: home,
-      meta: {
-        title: {
-          en: 'Literary platform | Watershed Foundation | A roof for writers | Eindhoven',
-          nl: 'Literair platform | Stichting Watershed | A roof for writers | Eindhoven',
-          pap: 'Literario platform | Fundashon Watershed | Un kas pa skirbi | Eindhoven',
-        },
-        description: {
-          en: 'Literary platform Watershed of the Watershed Foundation helps writers with literature. We are a stage for writers and do talent development for writers.',
-          nl: 'Literair platform Watershed van Stichting Watershed helpt schrijvers met literatuur. Wij zijn een podium voor schrijvers en doen aan talentontwikkeling voor schrijvers.',
-          pap: 'Literario platform Watershed di Fundashon Watershed yuda skirbi ku literatùra. Nos ta un podio pa skirbi i hasi desaroyo di talento pa skirbi.',
-        },
-      },
       slug: 'home',
       createdAt: fakerEN.date.past(),
       updatedAt: fakerEN.date.recent(),
     },
     {
-      title: {
-        en: 'About Us',
-        nl: 'Over Ons',
-        pap: 'Tokante Nos',
-      },
-      summary: {
-        en: 'Learn more about our organization',
-        nl: 'Lees meer over onze organisatie',
-        pap: 'Siña mas tokante nos organisashon',
-      },
       content: about,
-      meta: {
-        title: {
-          en: 'About Us',
-          nl: 'Over Ons',
-          pap: 'Tokante Nos',
-        },
-        description: {
-          en: 'Learn more about our organization and our mission.',
-          nl: 'Lees meer over onze organisatie en onze missie.',
-          pap: 'Siña mas tokante nos organisashon i nos mision',
-        },
-      },
       slug: 'about',
       createdAt: fakerEN.date.past(),
       updatedAt: fakerEN.date.recent(),
     },
     {
-      title: {
-        en: 'Contact',
-        nl: 'Contact',
-        pap: 'Kontakto',
-      },
-      summary: {
-        en: 'Get in touch with us',
-        nl: 'Neem contact met ons op',
-        pap: 'Tuma kontakto ku nos',
-      },
       content: contact,
-      meta: {
-        title: {
-          en: 'Contact Us',
-          nl: 'Neem Contact Met Ons Op',
-          pap: 'Kontakto Ku Nos',
-        },
-        description: {
-          en: 'Get in touch with us for any inquiries or support.',
-          nl: 'Neem contact met ons voor vragen of ondersteuning.',
-          pap: 'Tuma kontakto ku nos pa kualke pregunta of suport',
-        },
-      },
       slug: 'contact',
       createdAt: fakerEN.date.past(),
       updatedAt: fakerEN.date.recent(),

--- a/prisma/seed/_pageContent.ts
+++ b/prisma/seed/_pageContent.ts
@@ -1,9 +1,18 @@
-export const home = {
+import { WatershedPageData } from '~/config/puck.config';
+
+type SeedContent = {
+  en: WatershedPageData;
+  nl: WatershedPageData;
+  pap: WatershedPageData;
+};
+
+export const home: SeedContent = {
   en: {
     root: {
       props: {
         title: 'Welcome to our website',
         summary: 'The homepage of the website',
+        slug: 'home',
         meta: {
           title: 'Home | Stichting Watershed',
           description: 'Welcome to Stichting Watershed',
@@ -27,6 +36,7 @@ export const home = {
       props: {
         title: 'Welkom op onze website',
         summary: 'De hoofdpagina van de website',
+        slug: 'home',
         meta: {
           title: 'Hoofdpagina | Stichting Watershed',
           description: 'Welkom bij Stichting Watershed',
@@ -50,6 +60,7 @@ export const home = {
       props: {
         title: 'Welcome na nos website',
         summary: 'Homepage di nos website',
+        slug: 'home',
         meta: {
           title: 'Home | Stichting Watershed',
           description: 'Welcome na Stichting Watershed',
@@ -70,12 +81,13 @@ export const home = {
   },
 };
 
-export const about = {
+export const about: SeedContent = {
   en: {
     root: {
       props: {
         title: 'About Our Organization',
         summary: 'This is the about us page',
+        slug: 'about',
         meta: {
           title: 'About Our Organization | Stichting Watershed',
           description: 'Learn more about our organization',
@@ -116,6 +128,7 @@ export const about = {
       props: {
         title: 'Over Ons',
         summary: 'Dit is de over ons pagina',
+        slug: 'over-ons',
         meta: {
           title: 'Over ons | Stichting Watershed',
           description: 'Leer meer over onze organisatie',
@@ -156,6 +169,7 @@ export const about = {
       props: {
         title: 'Tokante Nos',
         summary: 'Welcome to our website',
+        slug: 'tokante-nos',
         meta: {
           title: 'Home | Stichting Watershed',
           description: 'This is our homepage.',
@@ -185,12 +199,13 @@ export const about = {
   },
 };
 
-export const contact = {
+export const contact: SeedContent = {
   en: {
     root: {
       props: {
         title: 'Contact Us',
         summary: 'This is the contact us page',
+        slug: 'contact',
         meta: {
           title: 'Contact us | Stichting Watershed',
           description: 'Get in touch with us',
@@ -214,6 +229,7 @@ export const contact = {
       props: {
         title: 'Neem contact op',
         summary: 'Dit is de contactpagina',
+        slug: 'contact',
         meta: {
           title: 'Neem contact op | Stichting Watershed',
           description: 'Neem contact met ons op',
@@ -237,6 +253,7 @@ export const contact = {
       props: {
         title: 'Kontakto Ku Nos',
         summary: 'Welcome to our website',
+        slug: 'kontakto-ku-nos',
         meta: {
           title: 'Home | Stichting Watershed',
           description: 'This is our homepage.',

--- a/prisma/seed/_pageContent.ts
+++ b/prisma/seed/_pageContent.ts
@@ -1,17 +1,17 @@
 export const home = {
   en: {
-    root: { title: 'Home' },
-    zones: {},
-    content: [
-      {
-        type: 'HeadingBlock',
-        props: {
-          id: 'Heading-1694032984497',
-          text: 'Welcome to our website',
-          align: 'center',
-          level: 1,
+    root: {
+      props: {
+        title: 'Welcome to our website',
+        summary: 'The homepage of the website',
+        meta: {
+          title: 'Home | Stichting Watershed',
+          description: 'Welcome to Stichting Watershed',
         },
       },
+    },
+    zones: {},
+    content: [
       {
         type: 'RichTextBlock',
         props: {
@@ -23,18 +23,18 @@ export const home = {
     ],
   },
   nl: {
-    root: { title: 'Home' },
-    zones: {},
-    content: [
-      {
-        type: 'HeadingBlock',
-        props: {
-          id: 'Heading-1694032984497',
-          text: 'Welkom op onze website',
-          align: 'center',
-          level: 1,
+    root: {
+      props: {
+        title: 'Welkom op onze website',
+        summary: 'De hoofdpagina van de website',
+        meta: {
+          title: 'Hoofdpagina | Stichting Watershed',
+          description: 'Welkom bij Stichting Watershed',
         },
       },
+    },
+    zones: {},
+    content: [
       {
         type: 'RichTextBlock',
         props: {
@@ -46,18 +46,18 @@ export const home = {
     ],
   },
   pap: {
-    root: { title: 'HOMES' },
-    zones: {},
-    content: [
-      {
-        type: 'HeadingBlock',
-        props: {
-          id: 'Heading-1694032984497',
-          text: 'Bienvenido na nos website',
-          align: 'center',
-          level: 1,
+    root: {
+      props: {
+        title: 'Welcome na nos website',
+        summary: 'Homepage di nos website',
+        meta: {
+          title: 'Home | Stichting Watershed',
+          description: 'Welcome na Stichting Watershed',
         },
       },
+    },
+    zones: {},
+    content: [
       {
         type: 'RichTextBlock',
         props: {
@@ -72,53 +72,96 @@ export const home = {
 
 export const about = {
   en: {
-    root: { title: 'About Us' },
-    zones: {},
-    content: [
-      {
-        type: 'HeadingBlock',
-        props: {
-          id: 'Heading-169403298449711',
-          text: 'About Our Organization',
-          align: 'center',
-          level: 1,
+    root: {
+      props: {
+        title: 'About Our Organization',
+        summary: 'This is the about us page',
+        meta: {
+          title: 'About Our Organization | Stichting Watershed',
+          description: 'Learn more about our organization',
         },
       },
+    },
+    zones: {},
+    content: [
       {
         type: 'RichTextBlock',
         props: {
           id: 'RichText-c8a0073a-9d67-4b30-8f31-281a76dedaa31122',
           content:
-            '<p>We are an organization committed to excellence. Founded in 2010, we have been serving our community for many years.</p><p>Our team consists of dedicated professionals who are passionate about their work.</p>',
+            '<p>We are an organization committed to excellence. Founded in 2010, we have been serving our community for many years.</p>',
+        },
+      },
+      {
+        type: 'HeadingBlock',
+        props: {
+          id: 'Heading-169403298449711',
+          text: 'Team',
+          align: 'center',
+          level: 2,
+        },
+      },
+      {
+        type: 'RichTextBlock',
+        props: {
+          id: 'RichText-c8a0073a-9d67-4b30-8f31-281a76dedaa3112244',
+          content:
+            '<p>Our team consists of dedicated professionals who are passionate about their work.</p>',
         },
       },
     ],
   },
   nl: {
-    root: { title: 'Over Ons' },
-    zones: {},
-    content: [
-      {
-        type: 'HeadingBlock',
-        props: {
-          id: 'Heading-169403298449711',
-          text: 'Over Onze Organisatie',
-          align: 'center',
-          level: 1,
+    root: {
+      props: {
+        title: 'Over Ons',
+        summary: 'Dit is de over ons pagina',
+        meta: {
+          title: 'Over ons | Stichting Watershed',
+          description: 'Leer meer over onze organisatie',
         },
       },
+    },
+    zones: {},
+    content: [
       {
         type: 'RichTextBlock',
         props: {
           id: 'RichText-c8a0073a-9d67-4b30-8f31-281a76dedaa31122',
           content:
-            '<p>Wij zijn een organisatie die zich inzet voor uitmuntendheid. Opgericht in 2010, dienen we onze gemeenschap al vele jaren.</p><p>Ons team bestaat uit toegewijde professionals die gepassioneerd zijn over hun werk.</p>',
+            '<p>Wij zijn een organisatie die zich inzet voor uitmuntendheid. Opgericht in 2010, dienen we onze gemeenschap al vele jaren.</p>',
+        },
+      },
+      {
+        type: 'HeadingBlock',
+        props: {
+          id: 'Heading-169403298449711',
+          text: 'Ons team',
+          align: 'center',
+          level: 2,
+        },
+      },
+      {
+        type: 'RichTextBlock',
+        props: {
+          id: 'RichText-c8a0073a-9d67-4b30-8f31-281a76dedaa3112266',
+          content:
+            '<p>Ons team bestaat uit toegewijde professionals die gepassioneerd zijn over hun werk.</p>',
         },
       },
     ],
   },
   pap: {
-    root: { title: 'Tokante Nos' },
+    root: {
+      props: {
+        title: 'Tokante Nos',
+        summary: 'Welcome to our website',
+        meta: {
+          title: 'Home | Stichting Watershed',
+          description: 'This is our homepage.',
+        },
+      },
+    },
     zones: {},
     content: [
       {
@@ -144,18 +187,18 @@ export const about = {
 
 export const contact = {
   en: {
-    root: { title: 'Contact Us' },
-    zones: {},
-    content: [
-      {
-        type: 'HeadingBlock',
-        props: {
-          id: 'Heading-1694032984497113344',
-          text: 'Contact Us',
-          align: 'center',
-          level: 1,
+    root: {
+      props: {
+        title: 'Contact Us',
+        summary: 'This is the contact us page',
+        meta: {
+          title: 'Contact us | Stichting Watershed',
+          description: 'Get in touch with us',
         },
       },
+    },
+    zones: {},
+    content: [
       {
         type: 'RichTextBlock',
         props: {
@@ -167,18 +210,18 @@ export const contact = {
     ],
   },
   nl: {
-    root: { title: 'Contact Us' },
-    zones: {},
-    content: [
-      {
-        type: 'HeadingBlock',
-        props: {
-          id: 'Heading-1694032984497113344',
-          text: 'Contact Us',
-          align: 'center',
-          level: 1,
+    root: {
+      props: {
+        title: 'Neem contact op',
+        summary: 'Dit is de contactpagina',
+        meta: {
+          title: 'Neem contact op | Stichting Watershed',
+          description: 'Neem contact met ons op',
         },
       },
+    },
+    zones: {},
+    content: [
       {
         type: 'RichTextBlock',
         props: {
@@ -190,7 +233,16 @@ export const contact = {
     ],
   },
   pap: {
-    root: { title: 'Kontakto Ku Nos' },
+    root: {
+      props: {
+        title: 'Kontakto Ku Nos',
+        summary: 'Welcome to our website',
+        meta: {
+          title: 'Home | Stichting Watershed',
+          description: 'This is our homepage.',
+        },
+      },
+    },
     zones: {},
     content: [
       {

--- a/scripts/diff-db-staging.zsh
+++ b/scripts/diff-db-staging.zsh
@@ -15,10 +15,16 @@ set -e
 # - LOCAL_DB_URL: URL for the local database (defaults to postgresql://postgres:postgres@localhost:5432/postgres)
 # ===============================================================
 
+# Check if run from the root directory (with package.json)
+if [[ ! -f package.json ]]; then
+  echo "ERROR: This script must be run from the root directory of the project."
+  exit 1
+fi
+
 # Load environment variables from .env file if it exists
-if [[ -f ../.env ]]; then
+if [[ -f ./.env ]]; then
   echo "Loading environment variables from .env file..."
-  source ../.env
+  source ./.env
 fi
 
 # Check required environment variables
@@ -83,22 +89,14 @@ trap '{
 }' EXIT INT TERM
 
 # Wait for port forwarding to be established with timeout
-# TODO: Use a more robust method to check if port-forwarding is established, since this gives an exit code that causes the diff to not run.
 log "Waiting for port-forwarding to be established (timeout: 15s)..."
 MAX_RETRIES=15
 count=0
-while true; do
-  # Use a different check method that doesn't exit the script
-  if (echo > /dev/tcp/localhost/$PORT_FORWARD_PORT) >/dev/null 2>&1; then
-    log "Port-forwarding successfully established"
-    break
-  fi
-
+while ! nc -z localhost $PORT_FORWARD_PORT 2>/dev/null; do
   if [[ $count -ge $MAX_RETRIES ]]; then
     log "ERROR: Port-forwarding failed to establish within timeout period"
     exit 1
   fi
-
   sleep 1
   ((count++))
 done


### PR DESCRIPTION
- **Reworked the Puck editor to support for page/SEO metadata.**
- **Created "new" flow for generic pages.**
- **Created "new" flow for generic pages.**
- **PageMutationForm now also shows errors, and made slug unique in prisma**
- **Rearranged all the components in Storybook. They are now categorised according to Atomic Design, and have been tagged.**
- **The slug can now also be set in Puck**
- **DB diff script is runnable from npm and fixed the wrong port check method.**
- **Ran prisma migrate to updated db to new schema**
- **Pages can now be edited and saved  Also added slugs to seeding scripts**
- **Changed some of the navigation labels**
- **Added page summary to the content table**
- **Fixed linting errors**
